### PR TITLE
Prototype - Support for configuartion of curve to use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	google.golang.org/grpc v1.31.0
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	gopkg.in/yaml.v2 v2.2.4 // indirect
 )
 
 replace github.com/onsi/gomega => github.com/onsi/gomega v1.9.0


### PR DESCRIPTION
Note PR for discussion of the approach (and being new to the codebase!)

- Needs an update to the idemix config protobuf to add in a CurveId field
- If a `idemixconfig.yaml` is present (peer of the existing files read) read, and take the curve specified in there as the one that needs to be used
- This is read and returned in the MSPConfig struct
- When the Idemix instance is setup it gets this MSPConfig struct passed so can create idemix as needed
- Note this meant some init code in `new` has moved to `setup`

Backward compatibility, if the file isn't there, or the field isn't there or known about, the original curve value is used.

Mathlib exports an enumeration for curveids, though these are ints - no ammenable to be used in a configuration file, therefore adopted a simple string naming. Ideally these should also be constants within mathlib

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>