### PR TITLE
throw error for no signerConfig file

### DIFF
--- a/idemixmsp.go
+++ b/idemixmsp.go
@@ -731,6 +731,8 @@ func GetIdemixMspConfig(dir string, ID string) (*m.MSPConfig, error) {
 			return nil, err
 		}
 		idemixConfig.Signer = signerConfig
+	} else {
+		return nil, err
 	}
 
 	confBytes, err := proto.Marshal(idemixConfig)


### PR DESCRIPTION
The idemix ignores NoSignerConfigFile error.
```go
        signerBytes, err := readFile(filepath.Join(dir, IdemixConfigDirUser, IdemixConfigFileSigner))
	if err == nil {
		signerConfig := &im.IdemixMSPSignerConfig{}
		err = proto.Unmarshal(signerBytes, signerConfig)
		if err != nil {
			return nil, err
		}
		idemixConfig.Signer = signerConfig
	} 

	confBytes, err := proto.Marshal(idemixConfig)
	if err != nil {
		return nil, err
	}

	return &m.MSPConfig{Config: confBytes, Type: int32(IDEMIX)}, nil
```
without `Signer` variable, MSPConfig will cause error of `msp.Setup(conf)`
For stable configuration setup and more readable error management, we should throw the error of MissingSignerConfigFile