### PR TITLE
[WIP] Revocation pk import fail

### DIFF
--- a/bccsp/idemix_suite_test.go
+++ b/bccsp/idemix_suite_test.go
@@ -8,11 +8,37 @@ package idemix_test
 import (
 	"testing"
 
+	idemix "github.com/IBM/idemix/bccsp"
+	"github.com/IBM/idemix/bccsp/schemes/dlog/crypto/translator/amcl"
+	bccsp "github.com/IBM/idemix/bccsp/types"
+	math "github.com/IBM/mathlib"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPlain(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Plain Suite")
+}
+
+func TestRevocationKeyExportImport(t *testing.T) {
+	curve := math.Curves[math.FP256BN_AMCL]
+	translator := &amcl.Fp256bn{C: curve}
+
+	var err error
+	CSP, err := idemix.New(NewDummyKeyStore(), curve, translator, true)
+	assert.NoError(t, err)
+
+	RevocationPrivateKey, err := CSP.KeyGen(&bccsp.IdemixRevocationKeyGenOpts{Temporary: true})
+	assert.NoError(t, err)
+
+	RevocationPublicKey, err := RevocationPrivateKey.PublicKey()
+	assert.NoError(t, err)
+
+	RevocationPublicKeyBytes, err := RevocationPublicKey.Bytes()
+	assert.NoError(t, err)
+
+	_, err = CSP.KeyImport(RevocationPublicKeyBytes, &bccsp.IdemixRevocationPublicKeyImportOpts{Temporary: true})
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
As demonstrated by the new test, importing an exported revocation public key fails