### PR TITLE
Switch to aries-bbs-go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ checks: check-deps
 
 .PHONY: unit-tests
 unit-tests:
-	@go test -timeout 480s -cover $(shell go list ./...)
+	find . -name go.mod -execdir go test ./... \;
 
 .PHONY: unit-tests-race
 unit-tests-race:

--- a/bccsp/bccsp.go
+++ b/bccsp/bccsp.go
@@ -14,7 +14,7 @@ import (
 	idemix "github.com/IBM/idemix/bccsp/schemes/dlog/crypto"
 	bccsp "github.com/IBM/idemix/bccsp/types"
 	math "github.com/IBM/mathlib"
-	"github.com/ale-linux/aries-framework-go/component/kmscrypto/crypto/primitive/bbs12381g2pub"
+	"github.com/hyperledger/aries-bbs-go/bbs"
 	"github.com/pkg/errors"
 )
 
@@ -252,7 +252,7 @@ func NewAries(keyStore bccsp.KeyStore, curve *math.Curve, _translator idemix.Tra
 		&handlers.CredentialSigner{
 			Credential: &aries.Cred{
 				Curve: curve,
-				Bls:   bbs12381g2pub.New(curve),
+				BBS:   bbs.New(curve),
 			},
 		})
 	base.AddWrapper(reflect.TypeOf(handlers.NewRevocationSecretKey(nil, true)),
@@ -291,7 +291,7 @@ func NewAries(keyStore bccsp.KeyStore, curve *math.Curve, _translator idemix.Tra
 		&handlers.CredentialVerifier{
 			Credential: &aries.Cred{
 				Curve: curve,
-				Bls:   bbs12381g2pub.New(curve),
+				BBS:   bbs.New(curve),
 			},
 		})
 	base.AddWrapper(reflect.TypeOf(handlers.NewRevocationPublicKey(nil)),

--- a/bccsp/schemes/aries/blind_sign.go
+++ b/bccsp/schemes/aries/blind_sign.go
@@ -13,13 +13,13 @@ import (
 
 	math "github.com/IBM/mathlib"
 	ml "github.com/IBM/mathlib"
-	"github.com/ale-linux/aries-framework-go/component/kmscrypto/crypto/primitive/bbs12381g2pub"
+	"github.com/hyperledger/aries-bbs-go/bbs"
 )
 
 // BlindedMessages represents a set of messages prepared
 // (blinded) to be submitted to a signer for a blind signature.
 type BlindedMessages struct {
-	PK  *bbs12381g2pub.PublicKeyWithGenerators
+	PK  *bbs.PublicKeyWithGenerators
 	S   *ml.Zr
 	C   *ml.G1
 	PoK *POKOfBlindedMessages
@@ -52,7 +52,7 @@ func ParseBlindedMessages(bytes []byte, curve *ml.Curve) (*BlindedMessages, erro
 
 	offset += curve.CompressedG1ByteSize
 
-	proof, err := bbs12381g2pub.NewBBSLib(curve).ParseProofG1(bytes[offset:])
+	proof, err := bbs.NewBBSLib(curve).ParseProofG1(bytes[offset:])
 	if err != nil {
 		return nil, fmt.Errorf("parse G1 proof: %w", err)
 	}
@@ -71,12 +71,12 @@ func ParseBlindedMessages(bytes []byte, curve *ml.Curve) (*BlindedMessages, erro
 // signature in the form of a Pedersen commitment.
 type POKOfBlindedMessages struct {
 	C      *ml.G1
-	ProofC *bbs12381g2pub.ProofG1
+	ProofC *bbs.ProofG1
 }
 
 // VerifyProof verifies the correctness of the zero knowledge
 // proof against the supplied commitment, challenge and public key.
-func (b *POKOfBlindedMessages) VerifyProof(messages []bool, commitment *ml.G1, challenge *ml.Zr, PK *bbs12381g2pub.PublicKey) error {
+func (b *POKOfBlindedMessages) VerifyProof(messages []bool, commitment *ml.G1, challenge *ml.Zr, PK *bbs.PublicKey) error {
 	pubKeyWithGenerators, err := PK.ToPublicKeyWithGenerators(len(messages))
 	if err != nil {
 		return fmt.Errorf("build generators from public key: %w", err)
@@ -102,18 +102,18 @@ func (b *POKOfBlindedMessages) VerifyProof(messages []bool, commitment *ml.G1, c
 
 // VerifyBlinding verifies that `msgCommit` is a valid
 // commitment of a set of messages against the appropriate bases.
-func VerifyBlinding(messageBitmap []bool, msgCommit *ml.G1, bmProof *POKOfBlindedMessages, PK *bbs12381g2pub.PublicKey, nonce []byte, curve *math.Curve) error {
+func VerifyBlinding(messageBitmap []bool, msgCommit *ml.G1, bmProof *POKOfBlindedMessages, PK *bbs.PublicKey, nonce []byte, curve *math.Curve) error {
 	challengeBytes := msgCommit.Bytes()
 	challengeBytes = append(challengeBytes, bmProof.C.Bytes()...)
 	challengeBytes = append(challengeBytes, nonce...)
 
-	return bmProof.VerifyProof(messageBitmap, msgCommit, bbs12381g2pub.FrFromOKM(challengeBytes, curve), PK)
+	return bmProof.VerifyProof(messageBitmap, msgCommit, bbs.FrFromOKM(challengeBytes, curve), PK)
 }
 
 // BlindMessages constructs a commitment to a set of messages
 // that need to be blinded before signing, and generates the
 // corresponding ZKP.
-func BlindMessages(messages [][]byte, PK *bbs12381g2pub.PublicKey, blindedMsgCount int, nonce []byte, curve *ml.Curve) (*BlindedMessages, error) {
+func BlindMessages(messages [][]byte, PK *bbs.PublicKey, blindedMsgCount int, nonce []byte, curve *ml.Curve) (*BlindedMessages, error) {
 	zrs := make([]*ml.Zr, len(messages))
 
 	for i, msg := range messages {
@@ -121,7 +121,7 @@ func BlindMessages(messages [][]byte, PK *bbs12381g2pub.PublicKey, blindedMsgCou
 			continue
 		}
 
-		zrs[i] = bbs12381g2pub.FrFromOKM(msg, curve)
+		zrs[i] = bbs.FrFromOKM(msg, curve)
 	}
 
 	return BlindMessagesZr(zrs, PK, blindedMsgCount, nonce, curve)
@@ -130,14 +130,14 @@ func BlindMessages(messages [][]byte, PK *bbs12381g2pub.PublicKey, blindedMsgCou
 // BlindMessagesZr constructs a commitment to a set of messages
 // that need to be blinded before signing, and generates the
 // corresponding ZKP.
-func BlindMessagesZr(zrs []*ml.Zr, PK *bbs12381g2pub.PublicKey, blindedMsgCount int, nonce []byte, curve *ml.Curve) (*BlindedMessages, error) {
+func BlindMessagesZr(zrs []*ml.Zr, PK *bbs.PublicKey, blindedMsgCount int, nonce []byte, curve *ml.Curve) (*BlindedMessages, error) {
 	pubKeyWithGenerators, err := PK.ToPublicKeyWithGenerators(len(zrs))
 	if err != nil {
 		return nil, fmt.Errorf("build generators from public key: %w", err)
 	}
 
-	commit := bbs12381g2pub.NewBBSLib(curve).NewProverCommittingG1()
-	cb := bbs12381g2pub.NewCommitmentBuilder(blindedMsgCount + 1)
+	commit := bbs.NewBBSLib(curve).NewProverCommittingG1()
+	cb := bbs.NewCommitmentBuilder(blindedMsgCount + 1)
 	secrets := make([]*ml.Zr, 0, blindedMsgCount+1)
 
 	s := curve.NewRandomZr(rand.Reader)
@@ -169,30 +169,44 @@ func BlindMessagesZr(zrs []*ml.Zr, PK *bbs12381g2pub.PublicKey, blindedMsgCount 
 		C:  C,
 		PoK: &POKOfBlindedMessages{
 			C:      U.Commitment,
-			ProofC: U.GenerateProof(bbs12381g2pub.FrFromOKM(challengeBytes, curve), secrets),
+			ProofC: U.GenerateProof(bbs.FrFromOKM(challengeBytes, curve), secrets),
 		},
 	}, nil
 }
 
 // BlindSign signs disclosed and blinded messages using private key in compressed form.
-func BlindSign(messages []*bbs12381g2pub.SignatureMessage, msgCount int, commitment *ml.G1, privKeyBytes []byte, curve *math.Curve) ([]byte, error) {
-	privKey, err := bbs12381g2pub.NewBBSLib(curve).UnmarshalPrivateKey(privKeyBytes)
+func BlindSign(messages []*bbs.SignatureMessage, msgCount int, commitment *ml.G1, privKeyBytes []byte, curve *math.Curve) ([]byte, error) {
+	bl := bbs.NewBBSLib(curve)
+
+	privKey, err := bl.UnmarshalPrivateKey(privKeyBytes)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal private key: %w", err)
+	}
+
+	pkwg, err := privKey.PublicKey().ToPublicKeyWithGenerators(msgCount)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal PublicKey: %w", err)
 	}
 
 	if len(messages) == 0 {
 		return nil, errors.New("messages are not defined")
 	}
 
-	bbs := bbs12381g2pub.New(curve)
+	// signer adds its component
+	cb := bbs.NewCommitmentBuilder(len(messages) + 2)
+	for _, msg := range messages {
+		cb.Add(pkwg.H[msg.Idx], msg.FR)
+	}
+	cb.Add(commitment, curve.NewZrFromInt(1))
+	cb.Add(curve.GenG1, curve.NewZrFromInt(1))
+	comm := cb.Build()
 
-	return bbs.SignWithKeyFr(messages, msgCount, commitment, privKey)
+	return bbs.New(curve).SignWithKeyB(comm, msgCount, privKey)
 }
 
 // UnblindSign converts a signature over some blind messages into a standard signature.
 func UnblindSign(sigBytes []byte, S *ml.Zr, curve *ml.Curve) ([]byte, error) {
-	signature, err := bbs12381g2pub.NewBBSLib(curve).ParseSignature(sigBytes)
+	signature, err := bbs.NewBBSLib(curve).ParseSignature(sigBytes)
 	if err != nil {
 		return nil, fmt.Errorf("parse signature: %w", err)
 	}

--- a/bccsp/schemes/aries/blind_sign_test.go
+++ b/bccsp/schemes/aries/blind_sign_test.go
@@ -14,12 +14,12 @@ import (
 	"github.com/IBM/idemix/bccsp/schemes/aries"
 	math "github.com/IBM/mathlib"
 	ml "github.com/IBM/mathlib"
-	"github.com/ale-linux/aries-framework-go/component/kmscrypto/crypto/primitive/bbs12381g2pub"
+	"github.com/hyperledger/aries-bbs-go/bbs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func generateKeyPairRandom(curve *math.Curve) (*bbs12381g2pub.PublicKey, *bbs12381g2pub.PrivateKey, error) {
+func generateKeyPairRandom(curve *math.Curve) (*bbs.PublicKey, *bbs.PrivateKey, error) {
 	seed := make([]byte, 32)
 
 	_, err := rand.Read(seed)
@@ -27,7 +27,7 @@ func generateKeyPairRandom(curve *math.Curve) (*bbs12381g2pub.PublicKey, *bbs123
 		panic(err)
 	}
 
-	return bbs12381g2pub.NewBBSLib(curve).GenerateKeyPair(sha256.New, seed)
+	return bbs.NewBBSLib(curve).GenerateKeyPair(sha256.New, seed)
 }
 
 func TestBlindSignMessages(t *testing.T) {
@@ -55,13 +55,13 @@ func TestBlindSignMessages(t *testing.T) {
 		[]byte("message4"),
 	}
 
-	msgToSign := []*bbs12381g2pub.SignatureMessage{
+	msgToSign := []*bbs.SignatureMessage{
 		{
-			FR:  bbs12381g2pub.FrFromOKM([]byte("message2"), curve),
+			FR:  bbs.FrFromOKM([]byte("message2"), curve),
 			Idx: 1,
 		},
 		{
-			FR:  bbs12381g2pub.FrFromOKM([]byte("message3"), curve),
+			FR:  bbs.FrFromOKM([]byte("message3"), curve),
 			Idx: 2,
 		},
 	}
@@ -85,7 +85,7 @@ func TestBlindSignMessages(t *testing.T) {
 	err = aries.VerifyBlinding(blindedMessagesBitmap, bm.C, bm.PoK, pubKey, []byte("nonce578"), curve)
 	assert.NoError(t, err)
 
-	bls := bbs12381g2pub.New(curve)
+	bls := bbs.New(curve)
 
 	privKeyBytes, err := privKey.Marshal()
 	require.NoError(t, err)
@@ -122,9 +122,9 @@ func TestBlindSignZr(t *testing.T) {
 		nil,
 	}
 
-	msgToSign := []*bbs12381g2pub.SignatureMessage{
+	msgToSign := []*bbs.SignatureMessage{
 		{
-			FR:  bbs12381g2pub.FrFromOKM([]byte("message2"), curve),
+			FR:  bbs.FrFromOKM([]byte("message2"), curve),
 			Idx: 1,
 		},
 	}
@@ -155,7 +155,7 @@ func TestBlindSignZr(t *testing.T) {
 	require.NotEmpty(t, signatureBytes)
 	require.Len(t, signatureBytes, 112)
 
-	signature, err := bbs12381g2pub.NewBBSLib(curve).ParseSignature(signatureBytes)
+	signature, err := bbs.NewBBSLib(curve).ParseSignature(signatureBytes)
 	require.NoError(t, err)
 
 	messagesCount := 2
@@ -163,7 +163,7 @@ func TestBlindSignZr(t *testing.T) {
 	publicKeyWithGenerators, err := pubKey.ToPublicKeyWithGenerators(messagesCount)
 	require.NoError(t, err)
 
-	messagesZr := []*bbs12381g2pub.SignatureMessage{
+	messagesZr := []*bbs.SignatureMessage{
 		{FR: zr, Idx: 0},
 		msgToSign[0],
 	}

--- a/bccsp/schemes/aries/cred.go
+++ b/bccsp/schemes/aries/cred.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/IBM/idemix/bccsp/types"
 	math "github.com/IBM/mathlib"
-	"github.com/ale-linux/aries-framework-go/component/kmscrypto/crypto/primitive/bbs12381g2pub"
 	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/aries-bbs-go/bbs"
 	"github.com/pkg/errors"
 )
 
 type Cred struct {
-	Bls                *bbs12381g2pub.BBSG2Pub
+	BBS                *bbs.BBSG2Pub
 	Curve              *math.Curve
 	UserSecretKeyIndex int
 }
@@ -74,16 +74,16 @@ func (c *Cred) Verify(sk *math.Zr, key types.IssuerPublicKey, credBytes []byte, 
 		return fmt.Errorf("proto.Unmarshal failed [%w]", err)
 	}
 
-	sigma, err := bbs12381g2pub.NewBBSLib(c.Curve).ParseSignature(credential.Cred)
+	sigma, err := bbs.NewBBSLib(c.Curve).ParseSignature(credential.Cred)
 	if err != nil {
 		return fmt.Errorf("ParseSignature failed [%w]", err)
 	}
 
 	i := 0
-	sm := make([]*bbs12381g2pub.SignatureMessage, len(ipk.PKwG.H))
+	sm := make([]*bbs.SignatureMessage, len(ipk.PKwG.H))
 	for j := range ipk.PKwG.H {
 		if j == int(credential.SkPos) {
-			sm[j] = &bbs12381g2pub.SignatureMessage{
+			sm[j] = &bbs.SignatureMessage{
 				FR:  sk,
 				Idx: j,
 			}
@@ -91,7 +91,7 @@ func (c *Cred) Verify(sk *math.Zr, key types.IssuerPublicKey, credBytes []byte, 
 			continue
 		}
 
-		sm[j] = &bbs12381g2pub.SignatureMessage{
+		sm[j] = &bbs.SignatureMessage{
 			FR:  c.Curve.NewZrFromBytes(credential.Attrs[i]),
 			Idx: j,
 		}
@@ -100,7 +100,7 @@ func (c *Cred) Verify(sk *math.Zr, key types.IssuerPublicKey, credBytes []byte, 
 		case types.IdemixHiddenAttribute:
 			continue
 		case types.IdemixBytesAttribute:
-			fr := bbs12381g2pub.FrFromOKM(attributes[i].Value.([]byte), c.Curve)
+			fr := bbs.FrFromOKM(attributes[i].Value.([]byte), c.Curve)
 			if !fr.Equals(sm[j].FR) {
 				return errors.Errorf("credential does not contain the correct attribute value at position [%d]", i)
 			}

--- a/bccsp/schemes/aries/credrequest_test.go
+++ b/bccsp/schemes/aries/credrequest_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/IBM/idemix/bccsp/schemes/aries"
 	"github.com/IBM/idemix/bccsp/types"
 	math "github.com/IBM/mathlib"
-	"github.com/ale-linux/aries-framework-go/component/kmscrypto/crypto/primitive/bbs12381g2pub"
+	"github.com/hyperledger/aries-bbs-go/bbs"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCredRequest(t *testing.T) {
 	credProto := &aries.Cred{
-		Bls:   bbs12381g2pub.New(math.Curves[math.BLS12_381_BBS]),
+		BBS:   bbs.New(math.Curves[math.BLS12_381_BBS]),
 		Curve: math.Curves[math.BLS12_381_BBS],
 	}
 	issuerProto := &aries.Issuer{math.Curves[math.BLS12_381_BBS]}

--- a/bccsp/schemes/aries/go.mod
+++ b/bccsp/schemes/aries/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/IBM/idemix/bccsp/schemes/weak-bb v0.0.0-20240612072411-114d281b442d
 	github.com/IBM/idemix/bccsp/types v0.0.0-20240612072411-114d281b442d
 	github.com/IBM/mathlib v0.0.3-0.20231011094432-44ee0eb539da
-	github.com/ale-linux/aries-framework-go/component/kmscrypto v0.0.0-20231023164747-f3f972769504
 	github.com/golang/protobuf v1.5.4
+	github.com/hyperledger/aries-bbs-go v0.0.0-20240528084656-761671ea73bc
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.9.0
 )

--- a/bccsp/schemes/aries/go.sum
+++ b/bccsp/schemes/aries/go.sum
@@ -4,8 +4,6 @@ github.com/IBM/idemix/bccsp/types v0.0.0-20240612072411-114d281b442d h1:cv8IVW3e
 github.com/IBM/idemix/bccsp/types v0.0.0-20240612072411-114d281b442d/go.mod h1:IMIJ8WcUpBmV4gcOO/BYKuFYpdXCPYZjpNhFSUlO9b8=
 github.com/IBM/mathlib v0.0.3-0.20231011094432-44ee0eb539da h1:qqGozq4tF6EOVnWoTgBoJGudRKKZXSAYnEtDggzTnsw=
 github.com/IBM/mathlib v0.0.3-0.20231011094432-44ee0eb539da/go.mod h1:Tco9QzE3fQzjMS7nPbHDeFfydAzctStf1Pa8hsh6Hjs=
-github.com/ale-linux/aries-framework-go/component/kmscrypto v0.0.0-20231023164747-f3f972769504 h1:sQyFeDcHVHWJ3IeE437NSJjv0+J/6MvGQOJew4X+Cuw=
-github.com/ale-linux/aries-framework-go/component/kmscrypto v0.0.0-20231023164747-f3f972769504/go.mod h1:z5xq4Ji1RQojJLZzKeZH5+LKCVZxgQRZpQ4xAJWi8r0=
 github.com/bits-and-blooms/bitset v1.13.0 h1:bAQ9OPNFYbGHV6Nez0tmNI0RiEu7/hxlYJRUA0wFAVE=
 github.com/bits-and-blooms/bitset v1.13.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce h1:YtWJF7RHm2pYCvA5t0RPmAaLUhREsKuKd+SLhxFbFeQ=
@@ -21,6 +19,8 @@ github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
+github.com/hyperledger/aries-bbs-go v0.0.0-20240528084656-761671ea73bc h1:3Ykk6MtyfnlzMOQry9zkxsoLWpCWZwDPqehO/BJwArM=
+github.com/hyperledger/aries-bbs-go v0.0.0-20240528084656-761671ea73bc/go.mod h1:Kofn6A6WWea1ZM8Rys5aBW9dszwJ7Ywa0kyyYL0TPYw=
 github.com/hyperledger/fabric-amcl v0.0.0-20230602173724-9e02669dceb2 h1:B1Nt8hKb//KvgGRprk0h1t4lCnwhE9/ryb1WqfZbV+M=
 github.com/hyperledger/fabric-amcl v0.0.0-20230602173724-9e02669dceb2/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
 github.com/kilic/bls12-381 v0.1.0 h1:encrdjqKMEvabVQ7qYOKu1OvhqpK4s47wDYtNiPtlp4=

--- a/bccsp/schemes/aries/issuer.go
+++ b/bccsp/schemes/aries/issuer.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/IBM/idemix/bccsp/types"
 	math "github.com/IBM/mathlib"
-	"github.com/ale-linux/aries-framework-go/component/kmscrypto/crypto/primitive/bbs12381g2pub"
+	"github.com/hyperledger/aries-bbs-go/bbs"
 )
 
 // TODO:
@@ -20,8 +20,8 @@ import (
 
 // IssuerPublicKey is the issuer public key
 type IssuerPublicKey struct {
-	PK   *bbs12381g2pub.PublicKey
-	PKwG *bbs12381g2pub.PublicKeyWithGenerators
+	PK   *bbs.PublicKey
+	PKwG *bbs.PublicKeyWithGenerators
 	// N is the number of attributes; it *does not* include the user secret key
 	N int
 }
@@ -40,7 +40,7 @@ func (i *IssuerPublicKey) Hash() []byte {
 // IssuerSecretKey is the issuer secret key
 type IssuerSecretKey struct {
 	IssuerPublicKey
-	SK *bbs12381g2pub.PrivateKey
+	SK *bbs.PrivateKey
 }
 
 // Bytes returns the byte representation of this key
@@ -67,7 +67,7 @@ func (i *Issuer) NewKey(AttributeNames []string) (types.IssuerSecretKey, error) 
 		return nil, fmt.Errorf("rand.Read failed [%w]", err)
 	}
 
-	PK, SK, err := bbs12381g2pub.NewBBSLib(i.Curve).GenerateKeyPair(sha256.New, seed)
+	PK, SK, err := bbs.NewBBSLib(i.Curve).GenerateKeyPair(sha256.New, seed)
 	if err != nil {
 		return nil, fmt.Errorf("GenerateKeyPair failed [%w]", err)
 	}
@@ -90,7 +90,7 @@ func (i *Issuer) NewKey(AttributeNames []string) (types.IssuerSecretKey, error) 
 // NewPublicKeyFromBytes converts the passed bytes to an Issuer key
 // It makes sure that the so obtained  key has the passed attributes, if specified
 func (i *Issuer) NewKeyFromBytes(raw []byte, attributes []string) (types.IssuerSecretKey, error) {
-	SK, err := bbs12381g2pub.NewBBSLib(i.Curve).UnmarshalPrivateKey(raw)
+	SK, err := bbs.NewBBSLib(i.Curve).UnmarshalPrivateKey(raw)
 	if err != nil {
 		return nil, fmt.Errorf("UnmarshalPrivateKey failed [%w]", err)
 	}
@@ -115,7 +115,7 @@ func (i *Issuer) NewKeyFromBytes(raw []byte, attributes []string) (types.IssuerS
 // NewPublicKeyFromBytes converts the passed bytes to an Issuer public key
 // It makes sure that the so obtained public key has the passed attributes, if specified
 func (i *Issuer) NewPublicKeyFromBytes(raw []byte, attributes []string) (types.IssuerPublicKey, error) {
-	PK, err := bbs12381g2pub.NewBBSLib(i.Curve).UnmarshalPublicKey(raw)
+	PK, err := bbs.NewBBSLib(i.Curve).UnmarshalPublicKey(raw)
 	if err != nil {
 		return nil, fmt.Errorf("UnmarshalPublicKey failed [%w]", err)
 	}

--- a/bccsp/schemes/aries/nymsigner_test.go
+++ b/bccsp/schemes/aries/nymsigner_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/IBM/idemix/bccsp/schemes/aries"
 	math "github.com/IBM/mathlib"
-	"github.com/ale-linux/aries-framework-go/component/kmscrypto/crypto/primitive/bbs12381g2pub"
+	"github.com/hyperledger/aries-bbs-go/bbs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -46,7 +46,7 @@ func TestNymSigner(t *testing.T) {
 	for skPos := range attrs {
 		signer.UserSecretKeyIndex = skPos
 
-		cb := bbs12381g2pub.NewCommitmentBuilder(2)
+		cb := bbs.NewCommitmentBuilder(2)
 		cb.Add(ipk.PKwG.H0, rNym)
 		cb.Add(ipk.PKwG.H[skPos], sk)
 		nym := cb.Build()

--- a/bccsp/schemes/aries/user.go
+++ b/bccsp/schemes/aries/user.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/IBM/idemix/bccsp/types"
 	math "github.com/IBM/mathlib"
-	"github.com/ale-linux/aries-framework-go/component/kmscrypto/crypto/primitive/bbs12381g2pub"
+	"github.com/hyperledger/aries-bbs-go/bbs"
 	"github.com/pkg/errors"
 )
 
@@ -49,7 +49,7 @@ func (u *User) MakeNym(sk *math.Zr, key types.IssuerPublicKey) (*math.G1, *math.
 
 	rNym := u.Curve.NewRandomZr(u.Rng)
 
-	cb := bbs12381g2pub.NewCommitmentBuilder(2)
+	cb := bbs.NewCommitmentBuilder(2)
 	cb.Add(ipk.PKwG.H0, rNym)
 	cb.Add(ipk.PKwG.H[u.UserSecretKeyIndex], sk)
 	nym := cb.Build()

--- a/bccsp/schemes/aries/util.go
+++ b/bccsp/schemes/aries/util.go
@@ -9,22 +9,22 @@ package aries
 import (
 	"github.com/IBM/idemix/bccsp/types"
 	math "github.com/IBM/mathlib"
-	"github.com/ale-linux/aries-framework-go/component/kmscrypto/crypto/primitive/bbs12381g2pub"
+	"github.com/hyperledger/aries-bbs-go/bbs"
 )
 
-func attributesToSignatureMessage(attributes []types.IdemixAttribute, curve *math.Curve, skPos int) []*bbs12381g2pub.SignatureMessage {
+func attributesToSignatureMessage(attributes []types.IdemixAttribute, curve *math.Curve, skPos int) []*bbs.SignatureMessage {
 	attributes = append(append(append([]types.IdemixAttribute{}, attributes[:skPos]...), types.IdemixAttribute{Type: types.IdemixHiddenAttribute}), attributes[skPos:]...)
-	var msgsZr = make([]*bbs12381g2pub.SignatureMessage, 0, len(attributes))
+	var msgsZr = make([]*bbs.SignatureMessage, 0, len(attributes))
 
 	for i, msg := range attributes {
 		switch msg.Type {
 		case types.IdemixBytesAttribute:
-			msgsZr = append(msgsZr, &bbs12381g2pub.SignatureMessage{
-				FR:  bbs12381g2pub.FrFromOKM(msg.Value.([]byte), curve),
+			msgsZr = append(msgsZr, &bbs.SignatureMessage{
+				FR:  bbs.FrFromOKM(msg.Value.([]byte), curve),
 				Idx: i,
 			})
 		case types.IdemixIntAttribute:
-			msgsZr = append(msgsZr, &bbs12381g2pub.SignatureMessage{
+			msgsZr = append(msgsZr, &bbs.SignatureMessage{
 				FR:  curve.NewZrFromInt(int64(msg.Value.(int))),
 				Idx: i,
 			})
@@ -60,12 +60,12 @@ func revealedAttributesIndex(attributes []types.IdemixAttribute) []int {
 	return revealed
 }
 
-func (c *Credential) toSignatureMessage(sk *math.Zr, curve *math.Curve) []*bbs12381g2pub.SignatureMessage {
-	msgsZr := make([]*bbs12381g2pub.SignatureMessage, 0, len(c.Attrs)+1)
+func (c *Credential) toSignatureMessage(sk *math.Zr, curve *math.Curve) []*bbs.SignatureMessage {
+	msgsZr := make([]*bbs.SignatureMessage, 0, len(c.Attrs)+1)
 
 	j := 0
 	for i := 0; i < len(c.Attrs)+1; i++ {
-		msg := &bbs12381g2pub.SignatureMessage{}
+		msg := &bbs.SignatureMessage{}
 		msgsZr = append(msgsZr, msg)
 
 		if i == int(c.SkPos) {

--- a/bccsp/smartcard_test.go
+++ b/bccsp/smartcard_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/IBM/idemix/bccsp/types"
 	"github.com/IBM/idemix/idemixmsp"
 	math "github.com/IBM/mathlib"
-	"github.com/ale-linux/aries-framework-go/component/kmscrypto/crypto/primitive/bbs12381g2pub"
 	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/aries-bbs-go/bbs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -119,7 +119,7 @@ func TestSmartcardHybrid(t *testing.T) {
 	sc.H0 = ipk.PKwG.H0
 	sc.H1 = ipk.PKwG.H[0]
 	sc.H2 = ipk.PKwG.H[3]
-	sc.EID = bbs12381g2pub.FrFromOKM([]byte(conf.EnrollmentId), curve)
+	sc.EID = bbs.FrFromOKM([]byte(conf.EnrollmentId), curve)
 	sc.Uid_sk = curve.NewZrFromBytes(conf.Sk)
 
 	/*******************************************************************************/
@@ -174,7 +174,7 @@ func TestSmartcardHybrid(t *testing.T) {
 		EidNymAuditData: &types.AttrNymAuditData{
 			Nym:  nymEid,
 			Rand: rNymEid,
-			Attr: bbs12381g2pub.FrFromOKM([]byte(conf.EnrollmentId), curve),
+			Attr: bbs.FrFromOKM([]byte(conf.EnrollmentId), curve),
 		},
 	}
 
@@ -243,7 +243,7 @@ func TestSmartcardCSP(t *testing.T) {
 	sc.H0 = ipk.PKwG.H0
 	sc.H1 = ipk.PKwG.H[0]
 	sc.H2 = ipk.PKwG.H[3]
-	sc.EID = bbs12381g2pub.FrFromOKM([]byte(conf.EnrollmentId), curve)
+	sc.EID = bbs.FrFromOKM([]byte(conf.EnrollmentId), curve)
 	sc.Uid_sk = curve.NewZrFromBytes(conf.Sk)
 
 	/*******************************************************************************/
@@ -307,7 +307,7 @@ func TestSmartcardCSP(t *testing.T) {
 			EidNymAuditData: &types.AttrNymAuditData{
 				Nym:  nymEid,
 				Rand: rNymEid,
-				Attr: bbs12381g2pub.FrFromOKM([]byte(conf.EnrollmentId), curve),
+				Attr: bbs.FrFromOKM([]byte(conf.EnrollmentId), curve),
 			},
 		},
 	}
@@ -374,7 +374,7 @@ func TestSmartcardCSP(t *testing.T) {
 			EidNymAuditData: &types.AttrNymAuditData{
 				Nym:  nymEid,
 				Rand: rNymEid,
-				Attr: bbs12381g2pub.FrFromOKM([]byte(conf.EnrollmentId), curve),
+				Attr: bbs.FrFromOKM([]byte(conf.EnrollmentId), curve),
 			},
 		},
 	}
@@ -437,7 +437,7 @@ func TestSmartcardCSP(t *testing.T) {
 		EidNymAuditData: &types.AttrNymAuditData{
 			Nym:  nymEid,
 			Rand: rNymEid,
-			Attr: bbs12381g2pub.FrFromOKM([]byte(conf.EnrollmentId), curve),
+			Attr: bbs.FrFromOKM([]byte(conf.EnrollmentId), curve),
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/IBM/idemix/bccsp/schemes/weak-bb v0.0.0-20240612072411-114d281b442d
 	github.com/IBM/idemix/bccsp/types v0.0.0-20240612072411-114d281b442d
 	github.com/IBM/mathlib v0.0.3-0.20231011094432-44ee0eb539da
-	github.com/ale-linux/aries-framework-go/component/kmscrypto v0.0.0-20231023164747-f3f972769504
 	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/golang/protobuf v1.5.4
+	github.com/hyperledger/aries-bbs-go v0.0.0-20240528084656-761671ea73bc
 	github.com/hyperledger/fabric-protos-go v0.3.3
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.34.1

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/IBM/idemix/bccsp/schemes/weak-bb v0.0.0-20240612072411-114d281b442d h
 github.com/IBM/idemix/bccsp/schemes/weak-bb v0.0.0-20240612072411-114d281b442d/go.mod h1:FC0vVgNI6bv8GH0VTwjup+arwJ8Tau1iEhroWZ1oPwU=
 github.com/IBM/mathlib v0.0.3-0.20231011094432-44ee0eb539da h1:qqGozq4tF6EOVnWoTgBoJGudRKKZXSAYnEtDggzTnsw=
 github.com/IBM/mathlib v0.0.3-0.20231011094432-44ee0eb539da/go.mod h1:Tco9QzE3fQzjMS7nPbHDeFfydAzctStf1Pa8hsh6Hjs=
-github.com/ale-linux/aries-framework-go/component/kmscrypto v0.0.0-20231023164747-f3f972769504 h1:sQyFeDcHVHWJ3IeE437NSJjv0+J/6MvGQOJew4X+Cuw=
-github.com/ale-linux/aries-framework-go/component/kmscrypto v0.0.0-20231023164747-f3f972769504/go.mod h1:z5xq4Ji1RQojJLZzKeZH5+LKCVZxgQRZpQ4xAJWi8r0=
 github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/units v0.0.0-20240626203959-61d1e3462e30 h1:t3eaIm0rUkzbrIewtiFmMK5RXHej2XnoXNhxVsAYUfg=
@@ -50,6 +48,8 @@ github.com/google/pprof v0.0.0-20240424215950-a892ee059fd6/go.mod h1:kf6iHlnVGwg
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/hyperledger/aries-bbs-go v0.0.0-20240528084656-761671ea73bc h1:3Ykk6MtyfnlzMOQry9zkxsoLWpCWZwDPqehO/BJwArM=
+github.com/hyperledger/aries-bbs-go v0.0.0-20240528084656-761671ea73bc/go.mod h1:Kofn6A6WWea1ZM8Rys5aBW9dszwJ7Ywa0kyyYL0TPYw=
 github.com/hyperledger/fabric-amcl v0.0.0-20230602173724-9e02669dceb2 h1:B1Nt8hKb//KvgGRprk0h1t4lCnwhE9/ryb1WqfZbV+M=
 github.com/hyperledger/fabric-amcl v0.0.0-20230602173724-9e02669dceb2/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
 github.com/hyperledger/fabric-protos-go v0.3.3 h1:0nssqz8QWJNVNBVQz+IIfAd2j1ku7QPKFSM/1anKizI=

--- a/tools/idemixgen/idemixca/iedmixca_aries.go
+++ b/tools/idemixgen/idemixca/iedmixca_aries.go
@@ -14,8 +14,8 @@ import (
 	bccsp "github.com/IBM/idemix/bccsp/types"
 	im "github.com/IBM/idemix/idemixmsp"
 	math "github.com/IBM/mathlib"
-	"github.com/ale-linux/aries-framework-go/component/kmscrypto/crypto/primitive/bbs12381g2pub"
 	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/aries-bbs-go/bbs"
 	"github.com/pkg/errors"
 )
 
@@ -79,7 +79,7 @@ func GenerateSignerConfigAries(
 
 	credentialSigner := &aries.Cred{
 		Curve: curve,
-		Bls:   bbs12381g2pub.New(curve),
+		BBS:   bbs.New(curve),
 	}
 
 	revocationAuthority := &aries.RevocationAuthority{


### PR DESCRIPTION
This PR stops using the fork of the aries code and uses the aries-bbs-go repo instead.