### PR TITLE
Extract the bases used for the commits

### DIFF
--- a/bccsp/handlers/issuer.go
+++ b/bccsp/handlers/issuer.go
@@ -133,6 +133,17 @@ func (i *IssuerPublicKeyImporter) KeyImport(raw interface{}, opts bccsp.KeyImpor
 		return nil, err
 	}
 
+	if o.CommitmentBasesRequest == bccsp.None {
+		goto done
+	}
+
+	if bases, err := i.Issuer.Bases(pk, o.CommitmentBasesRequest, o.RhIndex, o.EidIndex, o.SKIndex); err != nil {
+		return nil, err
+	} else {
+		o.CommitmentBases = bases
+	}
+
+done:
 	return &issuerPublicKey{pk}, nil
 }
 

--- a/bccsp/schemes/dlog/bridge/issuer.go
+++ b/bccsp/schemes/dlog/bridge/issuer.go
@@ -84,6 +84,10 @@ func (i *Issuer) NewKeyFromBytes(raw []byte, attributes []string) (res types.Iss
 	return
 }
 
+func (i *Issuer) Bases(ipk types.IssuerPublicKey, ipkType types.CommitmentBasesRequest, RhIndex, EidIndex, SKIndex int) (map[types.CommitmentType]interface{}, error) {
+	panic("not implemented")
+}
+
 func (i *Issuer) NewPublicKeyFromBytes(raw []byte, attributes []string) (res types.IssuerPublicKey, err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/bccsp/types/idemix.go
+++ b/bccsp/types/idemix.go
@@ -44,6 +44,10 @@ type Issuer interface {
 	// NewPublicKeyFromBytes converts the passed bytes to an Issuer public key
 	// It makes sure that the so obtained public key has the passed attributes, if specified
 	NewPublicKeyFromBytes(raw []byte, attributes []string) (IssuerPublicKey, error)
+
+	// Bases returns the bases used for committments produced by
+	// key `ipk` (when it is of an applicable type `ipkType`)
+	Bases(ipk IssuerPublicKey, ipkType CommitmentBasesRequest, RhIndex, EidIndex, SKIndex int) (map[CommitmentType]interface{}, error)
 }
 
 // User is a local interface to decouple from the idemix implementation

--- a/bccsp/types/idemixopts.go
+++ b/bccsp/types/idemixopts.go
@@ -44,11 +44,38 @@ func (o *IdemixIssuerKeyGenOpts) Ephemeral() bool {
 	return o.Temporary
 }
 
+// CommitmentBasesRequest describes the request for commitment bases
+type CommitmentBasesRequest int
+
+const (
+	None CommitmentBasesRequest = iota
+	Dlog
+)
+
+// CommitmentType describes a commitment performed by the scheme
+type CommitmentType int
+
+const (
+	Nym CommitmentType = iota + 1
+	NymEid
+	NymRH
+)
+
 // IdemixIssuerPublicKeyImportOpts contains the options for importing of an Idemix issuer public key.
 type IdemixIssuerPublicKeyImportOpts struct {
 	Temporary bool
 	// AttributeNames is a list of attributes to ensure the import public key has
 	AttributeNames []string
+	// CommitmentBasesRequest describes the request for commitment bases
+	CommitmentBasesRequest CommitmentBasesRequest
+	// RhIndex is the index of attribute containing the revocation handler.
+	RhIndex int
+	// EidIndex contains the index of the EID attribute
+	EidIndex int
+	// SKIndex contains the index of the secret key
+	SKIndex int
+	// CommitmentBases contains the bases used for the various commitments
+	CommitmentBases map[CommitmentType]interface{}
 }
 
 // Algorithm returns the key generation algorithm identifier (to be used).
@@ -296,7 +323,7 @@ type IdemixSignerOpts struct {
 	// RhIndex is the index of attribute containing the revocation handler.
 	// Notice that this attributed cannot be disclosed
 	RhIndex int
-	// EidIndex contains the index of the EID attrbiute
+	// EidIndex contains the index of the EID attribute
 	EidIndex int
 	// SKIndex contains the index of the secret key
 	SKIndex int

--- a/bccsp/types/mock/issuer.go
+++ b/bccsp/types/mock/issuer.go
@@ -8,6 +8,23 @@ import (
 )
 
 type Issuer struct {
+	BasesStub        func(types.IssuerPublicKey, types.CommitmentBasesRequest, int, int, int) (map[types.CommitmentType]interface{}, error)
+	basesMutex       sync.RWMutex
+	basesArgsForCall []struct {
+		arg1 types.IssuerPublicKey
+		arg2 types.CommitmentBasesRequest
+		arg3 int
+		arg4 int
+		arg5 int
+	}
+	basesReturns struct {
+		result1 map[types.CommitmentType]interface{}
+		result2 error
+	}
+	basesReturnsOnCall map[int]struct {
+		result1 map[types.CommitmentType]interface{}
+		result2 error
+	}
 	NewKeyStub        func([]string) (types.IssuerSecretKey, error)
 	newKeyMutex       sync.RWMutex
 	newKeyArgsForCall []struct {
@@ -51,6 +68,74 @@ type Issuer struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *Issuer) Bases(arg1 types.IssuerPublicKey, arg2 types.CommitmentBasesRequest, arg3 int, arg4 int, arg5 int) (map[types.CommitmentType]interface{}, error) {
+	fake.basesMutex.Lock()
+	ret, specificReturn := fake.basesReturnsOnCall[len(fake.basesArgsForCall)]
+	fake.basesArgsForCall = append(fake.basesArgsForCall, struct {
+		arg1 types.IssuerPublicKey
+		arg2 types.CommitmentBasesRequest
+		arg3 int
+		arg4 int
+		arg5 int
+	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.BasesStub
+	fakeReturns := fake.basesReturns
+	fake.recordInvocation("Bases", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.basesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *Issuer) BasesCallCount() int {
+	fake.basesMutex.RLock()
+	defer fake.basesMutex.RUnlock()
+	return len(fake.basesArgsForCall)
+}
+
+func (fake *Issuer) BasesCalls(stub func(types.IssuerPublicKey, types.CommitmentBasesRequest, int, int, int) (map[types.CommitmentType]interface{}, error)) {
+	fake.basesMutex.Lock()
+	defer fake.basesMutex.Unlock()
+	fake.BasesStub = stub
+}
+
+func (fake *Issuer) BasesArgsForCall(i int) (types.IssuerPublicKey, types.CommitmentBasesRequest, int, int, int) {
+	fake.basesMutex.RLock()
+	defer fake.basesMutex.RUnlock()
+	argsForCall := fake.basesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+}
+
+func (fake *Issuer) BasesReturns(result1 map[types.CommitmentType]interface{}, result2 error) {
+	fake.basesMutex.Lock()
+	defer fake.basesMutex.Unlock()
+	fake.BasesStub = nil
+	fake.basesReturns = struct {
+		result1 map[types.CommitmentType]interface{}
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *Issuer) BasesReturnsOnCall(i int, result1 map[types.CommitmentType]interface{}, result2 error) {
+	fake.basesMutex.Lock()
+	defer fake.basesMutex.Unlock()
+	fake.BasesStub = nil
+	if fake.basesReturnsOnCall == nil {
+		fake.basesReturnsOnCall = make(map[int]struct {
+			result1 map[types.CommitmentType]interface{}
+			result2 error
+		})
+	}
+	fake.basesReturnsOnCall[i] = struct {
+		result1 map[types.CommitmentType]interface{}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *Issuer) NewKey(arg1 []string) (types.IssuerSecretKey, error) {
@@ -275,6 +360,8 @@ func (fake *Issuer) NewPublicKeyFromBytesReturnsOnCall(i int, result1 types.Issu
 func (fake *Issuer) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.basesMutex.RLock()
+	defer fake.basesMutex.RUnlock()
 	fake.newKeyMutex.RLock()
 	defer fake.newKeyMutex.RUnlock()
 	fake.newKeyFromBytesMutex.RLock()


### PR DESCRIPTION
This PR adds support to retrieve the bases used for the commitments generated by the scheme.

Resolves #53