### PR TITLE
Fix credential verification bug

### DIFF
--- a/bccsp/schemes/aries/cred.go
+++ b/bccsp/schemes/aries/cred.go
@@ -98,7 +98,7 @@ func (c *Cred) Verify(sk *math.Zr, key types.IssuerPublicKey, credBytes []byte, 
 
 		switch attributes[i].Type {
 		case types.IdemixHiddenAttribute:
-			continue
+			goto end
 		case types.IdemixBytesAttribute:
 			fr := bbs.FrFromOKM(attributes[i].Value.([]byte), c.Curve)
 			if !fr.Equals(sm[j].FR) {
@@ -110,7 +110,7 @@ func (c *Cred) Verify(sk *math.Zr, key types.IssuerPublicKey, credBytes []byte, 
 				return errors.Errorf("credential does not contain the correct attribute value at position [%d]", i)
 			}
 		}
-
+	end:
 		i++
 	}
 

--- a/bccsp/schemes/aries/credrequest_test.go
+++ b/bccsp/schemes/aries/credrequest_test.go
@@ -109,6 +109,27 @@ func TestCredRequest(t *testing.T) {
 
 	idemixAttrs = []types.IdemixAttribute{
 		{
+			Type: types.IdemixHiddenAttribute,
+		},
+		{
+			Type:  types.IdemixIntAttribute,
+			Value: 3,
+		},
+		{
+			Type:  types.IdemixBytesAttribute,
+			Value: []byte("msg3"),
+		},
+		{
+			Type: types.IdemixHiddenAttribute,
+		},
+	}
+
+	// verify succeeds when supplying hidden attrs and one of the hidden attrs is not the last
+	err = credProto.Verify(sk, ipk, cred, idemixAttrs)
+	assert.NoError(t, err)
+
+	idemixAttrs = []types.IdemixAttribute{
+		{
 			Type:  types.IdemixBytesAttribute,
 			Value: []byte("msg2"),
 		},


### PR DESCRIPTION
This PR fixes a bug in the credential verification. The buggy code did not properly increment a counter for hidden attributes, leading to incorrect signature verification. The bug wasn't tested (despite the fact that we tested with hidden attributes) owing to the fact that the hidden attribute was last in the old tests, and so the missing increment did not matter. The code is now fixed and a new unit test is added.