### PR TITLE
perf:import the optimized aries-bbs module into idemix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,3 +42,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+replace github.com/hyperledger/aries-bbs-go => github.com/neetance/aries-bbs-go v0.0.0-20260523145523-32965e3d8c55

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
-github.com/hyperledger/aries-bbs-go v0.0.0-20240528084656-761671ea73bc h1:3Ykk6MtyfnlzMOQry9zkxsoLWpCWZwDPqehO/BJwArM=
-github.com/hyperledger/aries-bbs-go v0.0.0-20240528084656-761671ea73bc/go.mod h1:Kofn6A6WWea1ZM8Rys5aBW9dszwJ7Ywa0kyyYL0TPYw=
 github.com/hyperledger/fabric-amcl v0.0.0-20230602173724-9e02669dceb2 h1:B1Nt8hKb//KvgGRprk0h1t4lCnwhE9/ryb1WqfZbV+M=
 github.com/hyperledger/fabric-amcl v0.0.0-20230602173724-9e02669dceb2/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.3 h1:Xpd6fzG/KjAOHJsq7EQXY2l+qi/y8muxBaY7R6QWABk=
@@ -53,6 +51,8 @@ github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
+github.com/neetance/aries-bbs-go v0.0.0-20260523145523-32965e3d8c55 h1:X4Fj4qh1zO4upalyZJ1W73Auzn8O7tM/13V2f6d+poU=
+github.com/neetance/aries-bbs-go v0.0.0-20260523145523-32965e3d8c55/go.mod h1:Kofn6A6WWea1ZM8Rys5aBW9dszwJ7Ywa0kyyYL0TPYw=
 github.com/onsi/ginkgo/v2 v2.13.2 h1:Bi2gGVkfn6gQcjNjZJVO8Gf0FHzMPf2phUei9tejVMs=
 github.com/onsi/ginkgo/v2 v2.13.2/go.mod h1:XStQ8QcGwLyF4HdfcZB8SFOS/MWCgDuXMSBe6zrvLgM=
 github.com/onsi/gomega v1.31.0 h1:54UJxxj6cPInHS3a35wm6BK/F9nHYueZ1NVujHDrnXE=


### PR DESCRIPTION
## Summary

Replaces the `aries-bbs-go` dependency with an optimized fork that eliminates the primary performance bottlenecks in BBS+ signing, verification, and proof operations. The optimized implementation is imported as an independent Go module
via a `replace` directive, as suggested by @adecaro.

## Changes in the Optimized Fork

### 1. MSM Batching (`bbs.go`)
Replaced sequential `Mul` + `Add` calls in `sumOfG1Products` with `Mul2` pairing to process pairs in batches, reducing the number of individual scalar multiplication calls.

### 2. Generator Cache (`keys.go`)
Introduced `publicKeyGeneratorCache`, a struct owned by `BBSLib` whose lifecycle is tied to the `BBSLib` instance rather than the process.

```go
type publicKeyGeneratorCache struct {
    generators sync.Map
}

func newPublicKeyGeneratorCache() *publicKeyGeneratorCache {
    return &publicKeyGeneratorCache{}
}

func (c *publicKeyGeneratorCache) get(data []byte, curve *ml.Curve) *ml.G1 {
    if c == nil {
        return hashToG1(data, curve)
    }

    key := string(data)
    if cached, ok := c.generators.Load(key); ok {
        return cached.(*ml.G1)
    }

    generator := hashToG1(data, curve)
    cached, _ := c.generators.LoadOrStore(key, generator)

    return cached.(*ml.G1)
}
```

The full changes in the forked repo can be found [here](https://github.com/neetance/aries-bbs-go/tree/perf/mul2-optimizations)

## Benchmark results for Idemix

I ran `Benchmark_SignVerify` for both before and after the changes and here are the results:

- ### Before

```
goos: linux
goarch: amd64
pkg: github.com/IBM/idemix/bccsp
cpu: 13th Gen Intel(R) Core(TM) i5-13450HX
Benchmark_SignVerify/sign-legacy-16         	    2456	    463296 ns/op
Benchmark_SignVerify/sign-legacy-16         	    2284	    459566 ns/op
Benchmark_SignVerify/sign-legacy-16         	    2557	    451071 ns/op
Benchmark_SignVerify/sign-legacy-16         	    2367	    481330 ns/op
Benchmark_SignVerify/sign-legacy-16         	    2768	    445788 ns/op
Benchmark_SignVerify/verify-legacy-16       	    1522	    741913 ns/op
Benchmark_SignVerify/verify-legacy-16       	    1669	    729083 ns/op
Benchmark_SignVerify/verify-legacy-16       	    1592	    707307 ns/op
Benchmark_SignVerify/verify-legacy-16       	    1572	    752862 ns/op
Benchmark_SignVerify/verify-legacy-16       	    1621	    754706 ns/op
Benchmark_SignVerify/sign-aries-16          	    1614	    680451 ns/op
Benchmark_SignVerify/sign-aries-16          	    1814	    676492 ns/op
Benchmark_SignVerify/sign-aries-16          	    1867	    677873 ns/op
Benchmark_SignVerify/sign-aries-16          	    1658	    667028 ns/op
Benchmark_SignVerify/sign-aries-16          	    1694	    697726 ns/op
Benchmark_SignVerify/verify-aries-16        	    1772	    592744 ns/op
Benchmark_SignVerify/verify-aries-16        	    1852	    611659 ns/op
Benchmark_SignVerify/verify-aries-16        	    1954	    595495 ns/op
Benchmark_SignVerify/verify-aries-16        	    1888	    585800 ns/op
Benchmark_SignVerify/verify-aries-16        	    1855	    589481 ns/op
PASS
ok  	github.com/IBM/idemix/bccsp	26.345s
```

- ### After

```
goos: linux
goarch: amd64
pkg: github.com/IBM/idemix/bccsp
cpu: 13th Gen Intel(R) Core(TM) i5-13450HX
Benchmark_SignVerify/sign-legacy-16                 2818            468805 ns/op
Benchmark_SignVerify/sign-legacy-16                 2437            461810 ns/op
Benchmark_SignVerify/sign-legacy-16                 2230            463701 ns/op
Benchmark_SignVerify/sign-legacy-16                 2791            425753 ns/op
Benchmark_SignVerify/sign-legacy-16                 2512            429629 ns/op
Benchmark_SignVerify/verify-legacy-16               1713            701312 ns/op
Benchmark_SignVerify/verify-legacy-16               1760            704013 ns/op
Benchmark_SignVerify/verify-legacy-16               1616            693058 ns/op
Benchmark_SignVerify/verify-legacy-16               1773            699480 ns/op
Benchmark_SignVerify/verify-legacy-16               1533            706496 ns/op
Benchmark_SignVerify/sign-aries-16                  2060            579442 ns/op
Benchmark_SignVerify/sign-aries-16                  2089            573992 ns/op
Benchmark_SignVerify/sign-aries-16                  1911            566363 ns/op
Benchmark_SignVerify/sign-aries-16                  2109            571912 ns/op
Benchmark_SignVerify/sign-aries-16                  2034            570187 ns/op
Benchmark_SignVerify/verify-aries-16                2180            554506 ns/op
Benchmark_SignVerify/verify-aries-16                1863            546916 ns/op
Benchmark_SignVerify/verify-aries-16                2268            564125 ns/op
Benchmark_SignVerify/verify-aries-16                1960            571819 ns/op
Benchmark_SignVerify/verify-aries-16                2232            556930 ns/op
PASS
ok      github.com/IBM/idemix/bccsp     26.478s
```

- ### Comparison using benchstat

```
goos: linux
goarch: amd64
pkg: github.com/IBM/idemix/bccsp
cpu: 13th Gen Intel(R) Core(TM) i5-13450HX
                             │ original_bench.txt │         optimized_bench.txt         │
                             │       sec/op       │    sec/op     vs base               │
_SignVerify/sign-legacy-16           459.6µ ± ∞ ¹   461.8µ ± ∞ ¹        ~ (p=0.841 n=5)
_SignVerify/verify-legacy-16         741.9µ ± ∞ ¹   701.3µ ± ∞ ¹   -5.47% (p=0.008 n=5)
_SignVerify/sign-aries-16            677.9µ ± ∞ ¹   571.9µ ± ∞ ¹  -15.63% (p=0.008 n=5)
_SignVerify/verify-aries-16          592.7µ ± ∞ ¹   556.9µ ± ∞ ¹   -6.04% (p=0.008 n=5)
geomean                              608.4µ         566.7µ         -6.85%
```

We can see that aries-signing shows an improvement of **15.63%** and verification an improvement of **6%**

## Testing

All existing tests pass with `make unit-tests` and `make unit-tests-race`

Let me know if this is good 🙏 