### PR TITLE
Repository Modernization Plan - Phase 2A: Remove unused Hash, Encrypt, Decrypt from BCCSP interface

### DIFF
--- a/bccsp/impl.go
+++ b/bccsp/impl.go
@@ -15,7 +15,6 @@ limitations under the License.
 package idemix
 
 import (
-	"hash"
 	"reflect"
 
 	bccsp "github.com/IBM/idemix/bccsp/types"
@@ -50,22 +49,6 @@ type KeyImporter interface {
 	KeyImport(raw interface{}, opts bccsp.KeyImportOpts) (k bccsp.Key, err error)
 }
 
-// Encryptor is a BCCSP-like interface that provides encryption algorithms
-type Encryptor interface {
-
-	// Encrypt encrypts plaintext using key k.
-	// The opts argument should be appropriate for the algorithm used.
-	Encrypt(k bccsp.Key, plaintext []byte, opts bccsp.EncrypterOpts) (ciphertext []byte, err error)
-}
-
-// Decryptor is a BCCSP-like interface that provides decryption algorithms
-type Decryptor interface {
-
-	// Decrypt decrypts ciphertext using key k.
-	// The opts argument should be appropriate for the algorithm used.
-	Decrypt(k bccsp.Key, ciphertext []byte, opts bccsp.DecrypterOpts) (plaintext []byte, err error)
-}
-
 // Signer is a BCCSP-like interface that provides signing algorithms
 type Signer interface {
 
@@ -86,34 +69,19 @@ type Verifier interface {
 	Verify(k bccsp.Key, signature, digest []byte, opts bccsp.SignerOpts) (valid bool, err error)
 }
 
-// Hasher is a BCCSP-like interface that provides hash algorithms
-type Hasher interface {
-
-	// Hash hashes messages msg using options opts.
-	// If opts is nil, the default hash function will be used.
-	Hash(msg []byte, opts bccsp.HashOpts) (hash []byte, err error)
-
-	// GetHash returns and instance of hash.Hash using options opts.
-	// If opts is nil, the default hash function will be returned.
-	GetHash(opts bccsp.HashOpts) (h hash.Hash, err error)
-}
-
 // CSP provides a generic implementation of the BCCSP interface based
 // on wrappers. It can be customized by providing implementations for the
 // following algorithm-based wrappers: KeyGenerator, KeyDeriver, KeyImporter,
-// Encryptor, Decryptor, Signer, Verifier, Hasher. Each wrapper is bound to a
-// goland type representing either an option or a key.
+// Signer, Verifier. Each wrapper is bound to a Go type representing either
+// an option or a key.
 type CSP struct {
 	ks bccsp.KeyStore
 
 	KeyGenerators map[reflect.Type]KeyGenerator
 	KeyDerivers   map[reflect.Type]KeyDeriver
 	KeyImporters  map[reflect.Type]KeyImporter
-	Encryptors    map[reflect.Type]Encryptor
-	Decryptors    map[reflect.Type]Decryptor
 	Signers       map[reflect.Type]Signer
 	Verifiers     map[reflect.Type]Verifier
-	Hashers       map[reflect.Type]Hasher
 }
 
 func NewImpl(keyStore bccsp.KeyStore) (*CSP, error) {
@@ -121,18 +89,15 @@ func NewImpl(keyStore bccsp.KeyStore) (*CSP, error) {
 		return nil, errors.Errorf("Invalid bccsp.KeyStore instance. It must be different from nil.")
 	}
 
-	encryptors := make(map[reflect.Type]Encryptor)
-	decryptors := make(map[reflect.Type]Decryptor)
 	signers := make(map[reflect.Type]Signer)
 	verifiers := make(map[reflect.Type]Verifier)
-	hashers := make(map[reflect.Type]Hasher)
 	keyGenerators := make(map[reflect.Type]KeyGenerator)
 	keyDerivers := make(map[reflect.Type]KeyDeriver)
 	keyImporters := make(map[reflect.Type]KeyImporter)
 
 	csp := &CSP{keyStore,
-		keyGenerators, keyDerivers, keyImporters, encryptors,
-		decryptors, signers, verifiers, hashers}
+		keyGenerators, keyDerivers, keyImporters,
+		signers, verifiers}
 
 	return csp, nil
 }
@@ -243,47 +208,6 @@ func (csp *CSP) GetKey(ski []byte) (k bccsp.Key, err error) {
 	return
 }
 
-// Hash hashes messages msg using options opts.
-func (csp *CSP) Hash(msg []byte, opts bccsp.HashOpts) (digest []byte, err error) {
-	// Validate arguments
-	if opts == nil {
-		return nil, errors.New("Invalid opts. It must not be nil.")
-	}
-
-	hasher, found := csp.Hashers[reflect.TypeOf(opts)]
-	if !found {
-		return nil, errors.Errorf("Unsupported 'HashOpt' provided [%v]", opts)
-	}
-
-	digest, err = hasher.Hash(msg, opts)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed hashing with opts [%v]", opts)
-	}
-
-	return
-}
-
-// GetHash returns and instance of hash.Hash using options opts.
-// If opts is nil then the default hash function is returned.
-func (csp *CSP) GetHash(opts bccsp.HashOpts) (h hash.Hash, err error) {
-	// Validate arguments
-	if opts == nil {
-		return nil, errors.New("Invalid opts. It must not be nil.")
-	}
-
-	hasher, found := csp.Hashers[reflect.TypeOf(opts)]
-	if !found {
-		return nil, errors.Errorf("Unsupported 'HashOpt' provided [%v]", opts)
-	}
-
-	h, err = hasher.GetHash(opts)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed getting hash function with opts [%v]", opts)
-	}
-
-	return
-}
-
 // Sign signs digest using key k.
 // The opts argument should be appropriate for the primitive used.
 //
@@ -339,46 +263,9 @@ func (csp *CSP) Verify(k bccsp.Key, signature, digest []byte, opts bccsp.SignerO
 	return
 }
 
-// Encrypt encrypts plaintext using key k.
-// The opts argument should be appropriate for the primitive used.
-func (csp *CSP) Encrypt(k bccsp.Key, plaintext []byte, opts bccsp.EncrypterOpts) ([]byte, error) {
-	// Validate arguments
-	if k == nil {
-		return nil, errors.New("Invalid Key. It must not be nil.")
-	}
-
-	encryptor, found := csp.Encryptors[reflect.TypeOf(k)]
-	if !found {
-		return nil, errors.Errorf("Unsupported 'EncryptKey' provided [%v]", k)
-	}
-
-	return encryptor.Encrypt(k, plaintext, opts)
-}
-
-// Decrypt decrypts ciphertext using key k.
-// The opts argument should be appropriate for the primitive used.
-func (csp *CSP) Decrypt(k bccsp.Key, ciphertext []byte, opts bccsp.DecrypterOpts) (plaintext []byte, err error) {
-	// Validate arguments
-	if k == nil {
-		return nil, errors.New("Invalid Key. It must not be nil.")
-	}
-
-	decryptor, found := csp.Decryptors[reflect.TypeOf(k)]
-	if !found {
-		return nil, errors.Errorf("Unsupported 'DecryptKey' provided [%v]", k)
-	}
-
-	plaintext, err = decryptor.Decrypt(k, ciphertext, opts)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Failed decrypting with opts [%v]", opts)
-	}
-
-	return
-}
-
 // AddWrapper binds the passed type to the passed wrapper.
 // Notice that that wrapper must be an instance of one of the following interfaces:
-// KeyGenerator, KeyDeriver, KeyImporter, Encryptor, Decryptor, Signer, Verifier, Hasher.
+// KeyGenerator, KeyDeriver, KeyImporter, Signer, Verifier.
 func (csp *CSP) AddWrapper(t reflect.Type, w interface{}) error {
 	if t == nil {
 		return errors.Errorf("type cannot be nil")
@@ -393,18 +280,12 @@ func (csp *CSP) AddWrapper(t reflect.Type, w interface{}) error {
 		csp.KeyImporters[t] = dt
 	case KeyDeriver:
 		csp.KeyDerivers[t] = dt
-	case Encryptor:
-		csp.Encryptors[t] = dt
-	case Decryptor:
-		csp.Decryptors[t] = dt
 	case Signer:
 		csp.Signers[t] = dt
 	case Verifier:
 		csp.Verifiers[t] = dt
-	case Hasher:
-		csp.Hashers[t] = dt
 	default:
-		return errors.Errorf("wrapper type not valid, must be on of: KeyGenerator, KeyDeriver, KeyImporter, Encryptor, Decryptor, Signer, Verifier, Hasher")
+		return errors.Errorf("wrapper type not valid, must be one of: KeyGenerator, KeyDeriver, KeyImporter, Signer, Verifier")
 	}
 	return nil
 }

--- a/bccsp/types/crypto.go
+++ b/bccsp/types/crypto.go
@@ -7,7 +7,6 @@ package types
 
 import (
 	"crypto"
-	"hash"
 )
 
 // KeyStore represents a storage system for cryptographic keys.
@@ -84,23 +83,10 @@ type KeyImportOpts interface {
 	Ephemeral() bool
 }
 
-// HashOpts contains options for hashing with a CSP.
-type HashOpts interface {
-
-	// Algorithm returns the hash algorithm identifier (to be used).
-	Algorithm() string
-}
-
 // SignerOpts contains options for signing with a CSP.
 type SignerOpts interface {
 	crypto.SignerOpts
 }
-
-// EncrypterOpts contains options for encrypting with a CSP.
-type EncrypterOpts interface{}
-
-// DecrypterOpts contains options for decrypting with a CSP.
-type DecrypterOpts interface{}
 
 // BCCSP is the blockchain cryptographic service provider that offers
 // the implementation of cryptographic standards and algorithms.
@@ -121,14 +107,6 @@ type BCCSP interface {
 	// the Subject Key Identifier ski.
 	GetKey(ski []byte) (k Key, err error)
 
-	// Hash hashes messages msg using options opts.
-	// If opts is nil, the default hash function will be used.
-	Hash(msg []byte, opts HashOpts) (hash []byte, err error)
-
-	// GetHash returns and instance of hash.Hash using options opts.
-	// If opts is nil, the default hash function will be returned.
-	GetHash(opts HashOpts) (h hash.Hash, err error)
-
 	// Sign signs digest using key k.
 	// The opts argument should be appropriate for the algorithm used.
 	//
@@ -140,12 +118,4 @@ type BCCSP interface {
 	// Verify verifies signature against key k and digest
 	// The opts argument should be appropriate for the algorithm used.
 	Verify(k Key, signature, digest []byte, opts SignerOpts) (valid bool, err error)
-
-	// Encrypt encrypts plaintext using key k.
-	// The opts argument should be appropriate for the algorithm used.
-	Encrypt(k Key, plaintext []byte, opts EncrypterOpts) (ciphertext []byte, err error)
-
-	// Decrypt decrypts ciphertext using key k.
-	// The opts argument should be appropriate for the algorithm used.
-	Decrypt(k Key, ciphertext []byte, opts DecrypterOpts) (plaintext []byte, err error)
 }


### PR DESCRIPTION
## Remove unused Hash, Encrypt, Decrypt from BCCSP interface


Fixes #63 

### What

Removes dead methods from the `BCCSP` interface and `CSP` implementation that were inherited from Hyperledger Fabric's generic crypto provider but are never used by Idemix.

### Removed from `bccsp/types/crypto.go`
- `Hash(msg []byte, opts HashOpts) ([]byte, error)`
- `GetHash(opts HashOpts) (hash.Hash, error)`
- `Encrypt(k Key, plaintext []byte, opts EncrypterOpts) ([]byte, error)`
- `Decrypt(k Key, ciphertext []byte, opts DecrypterOpts) ([]byte, error)`
- `HashOpts` interface
- `EncrypterOpts` interface
- `DecrypterOpts` interface
- Unused `"hash"` import

### Removed from `bccsp/impl.go`
- `Encryptor` interface
- `Decryptor` interface
- `Hasher` interface
- `CSP.Encryptors`, `CSP.Decryptors`, `CSP.Hashers` map fields
- `CSP.Hash()`, `CSP.GetHash()`, `CSP.Encrypt()`, `CSP.Decrypt()` methods
- Corresponding `AddWrapper` cases for Encryptor/Decryptor/Hasher

### Why

Idemix is a zero-knowledge proof / signature scheme. It never performs symmetric encryption, decryption, or standalone hashing via the BCCSP interface. These methods were vestiges from Fabric's pluggable CSP architecture that supported multiple backends (SW, PKCS#11). Neither `New()` nor `NewAries()` ever registers any Encryptor, Decryptor, or Hasher handler.

### Remaining BCCSP interface (6 methods)
```go
KeyGen | KeyDeriv | KeyImport | GetKey | Sign | Verify