### PR TITLE
Repository Modernization Plan - Phase 2B: Remove redundant Algorithm() from Opts interfaces

### DIFF
--- a/bccsp/impl.go
+++ b/bccsp/impl.go
@@ -124,7 +124,7 @@ func (csp *CSP) KeyGen(opts bccsp.KeyGenOpts) (k bccsp.Key, err error) {
 		// Store the key
 		err = csp.ks.StoreKey(k)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Failed storing key [%s]", opts.Algorithm())
+			return nil, errors.Wrapf(err, "Failed storing key [%v]", reflect.TypeOf(opts))
 		}
 	}
 
@@ -157,7 +157,7 @@ func (csp *CSP) KeyDeriv(k bccsp.Key, opts bccsp.KeyDerivOpts) (dk bccsp.Key, er
 		// Store the key
 		err = csp.ks.StoreKey(k)
 		if err != nil {
-			return nil, errors.Wrapf(err, "Failed storing key [%s]", opts.Algorithm())
+			return nil, errors.Wrapf(err, "Failed storing key [%v]", reflect.TypeOf(opts))
 		}
 	}
 

--- a/bccsp/types/crypto.go
+++ b/bccsp/types/crypto.go
@@ -53,9 +53,6 @@ type Key interface {
 // KeyGenOpts contains options for key-generation with a CSP.
 type KeyGenOpts interface {
 
-	// Algorithm returns the key generation algorithm identifier (to be used).
-	Algorithm() string
-
 	// Ephemeral returns true if the key to generate has to be ephemeral,
 	// false otherwise.
 	Ephemeral() bool
@@ -64,9 +61,6 @@ type KeyGenOpts interface {
 // KeyDerivOpts contains options for key-derivation with a CSP.
 type KeyDerivOpts interface {
 
-	// Algorithm returns the key derivation algorithm identifier (to be used).
-	Algorithm() string
-
 	// Ephemeral returns true if the key to derived has to be ephemeral,
 	// false otherwise.
 	Ephemeral() bool
@@ -74,9 +68,6 @@ type KeyDerivOpts interface {
 
 // KeyImportOpts contains options for importing the raw material of a key with a CSP.
 type KeyImportOpts interface {
-
-	// Algorithm returns the key importation algorithm identifier (to be used).
-	Algorithm() string
 
 	// Ephemeral returns true if the key generated has to be ephemeral,
 	// false otherwise.

--- a/bccsp/types/idemixopts.go
+++ b/bccsp/types/idemixopts.go
@@ -15,11 +15,6 @@ import (
 type RevocationAlgorithm int32
 
 const (
-	// IDEMIX constant to identify Idemix related algorithms
-	IDEMIX = "IDEMIX"
-)
-
-const (
 	// AlgNoRevocation means no revocation support
 	AlgNoRevocation RevocationAlgorithm = iota
 )
@@ -31,11 +26,6 @@ type IdemixIssuerKeyGenOpts struct {
 	Temporary bool
 	// AttributeNames is a list of attributes
 	AttributeNames []string
-}
-
-// Algorithm returns the key generation algorithm identifier (to be used).
-func (*IdemixIssuerKeyGenOpts) Algorithm() string {
-	return IDEMIX
 }
 
 // Ephemeral returns true if the key to generate has to be ephemeral,
@@ -78,11 +68,6 @@ type IdemixIssuerPublicKeyImportOpts struct {
 	CommitmentBases map[CommitmentType]interface{}
 }
 
-// Algorithm returns the key generation algorithm identifier (to be used).
-func (*IdemixIssuerPublicKeyImportOpts) Algorithm() string {
-	return IDEMIX
-}
-
 // Ephemeral returns true if the key to generate has to be ephemeral,
 // false otherwise.
 func (o *IdemixIssuerPublicKeyImportOpts) Ephemeral() bool {
@@ -96,11 +81,6 @@ type IdemixIssuerKeyImportOpts struct {
 	AttributeNames []string
 }
 
-// Algorithm returns the key generation algorithm identifier (to be used).
-func (*IdemixIssuerKeyImportOpts) Algorithm() string {
-	return IDEMIX
-}
-
 // Ephemeral returns true if the key to generate has to be ephemeral,
 // false otherwise.
 func (o *IdemixIssuerKeyImportOpts) Ephemeral() bool {
@@ -112,11 +92,6 @@ type IdemixUserSecretKeyGenOpts struct {
 	Temporary bool
 }
 
-// Algorithm returns the key generation algorithm identifier (to be used).
-func (*IdemixUserSecretKeyGenOpts) Algorithm() string {
-	return IDEMIX
-}
-
 // Ephemeral returns true if the key to generate has to be ephemeral,
 // false otherwise.
 func (o *IdemixUserSecretKeyGenOpts) Ephemeral() bool {
@@ -126,11 +101,6 @@ func (o *IdemixUserSecretKeyGenOpts) Ephemeral() bool {
 // IdemixUserSecretKeyImportOpts contains the options for importing of an Idemix credential secret key.
 type IdemixUserSecretKeyImportOpts struct {
 	Temporary bool
-}
-
-// Algorithm returns the key generation algorithm identifier (to be used).
-func (*IdemixUserSecretKeyImportOpts) Algorithm() string {
-	return IDEMIX
 }
 
 // Ephemeral returns true if the key to generate has to be ephemeral,
@@ -146,11 +116,6 @@ type IdemixNymKeyDerivationOpts struct {
 	Temporary bool
 	// IssuerPK is the public-key of the issuer
 	IssuerPK Key
-}
-
-// Algorithm returns the key derivation algorithm identifier (to be used).
-func (*IdemixNymKeyDerivationOpts) Algorithm() string {
-	return IDEMIX
 }
 
 // Ephemeral returns true if the key to derive has to be ephemeral,
@@ -171,11 +136,6 @@ type IdemixNymPublicKeyImportOpts struct {
 	Temporary bool
 }
 
-// Algorithm returns the key derivation algorithm identifier (to be used).
-func (*IdemixNymPublicKeyImportOpts) Algorithm() string {
-	return IDEMIX
-}
-
 // Ephemeral returns true if the key to derive has to be ephemeral,
 // false otherwise.
 func (o *IdemixNymPublicKeyImportOpts) Ephemeral() bool {
@@ -186,11 +146,6 @@ func (o *IdemixNymPublicKeyImportOpts) Ephemeral() bool {
 type IdemixNymKeyImportOpts struct {
 	// Temporary tells if the key is ephemeral
 	Temporary bool
-}
-
-// Algorithm returns the key derivation algorithm identifier (to be used).
-func (*IdemixNymKeyImportOpts) Algorithm() string {
-	return IDEMIX
 }
 
 // Ephemeral returns true if the key to derive has to be ephemeral,
@@ -413,11 +368,6 @@ type IdemixRevocationKeyGenOpts struct {
 	Temporary bool
 }
 
-// Algorithm returns the key generation algorithm identifier (to be used).
-func (*IdemixRevocationKeyGenOpts) Algorithm() string {
-	return IDEMIX
-}
-
 // Ephemeral returns true if the key to generate has to be ephemeral,
 // false otherwise.
 func (o *IdemixRevocationKeyGenOpts) Ephemeral() bool {
@@ -429,11 +379,6 @@ type IdemixRevocationPublicKeyImportOpts struct {
 	Temporary bool
 }
 
-// Algorithm returns the key generation algorithm identifier (to be used).
-func (*IdemixRevocationPublicKeyImportOpts) Algorithm() string {
-	return IDEMIX
-}
-
 // Ephemeral returns true if the key to generate has to be ephemeral,
 // false otherwise.
 func (o *IdemixRevocationPublicKeyImportOpts) Ephemeral() bool {
@@ -443,11 +388,6 @@ func (o *IdemixRevocationPublicKeyImportOpts) Ephemeral() bool {
 // IdemixRevocationKeyImportOpts contains the options for importing of an Idemix revocation key pair.
 type IdemixRevocationKeyImportOpts struct {
 	Temporary bool
-}
-
-// Algorithm returns the key generation algorithm identifier (to be used).
-func (*IdemixRevocationKeyImportOpts) Algorithm() string {
-	return IDEMIX
 }
 
 // Ephemeral returns true if the key to generate has to be ephemeral,


### PR DESCRIPTION
## Remove redundant Algorithm() from Opts interfaces

Fixes #63 

### What

Removes the `Algorithm() string` method from `KeyGenOpts`, `KeyDerivOpts`, and `KeyImportOpts` interfaces, along with all 11 boilerplate implementations across opts structs.

### Why

Every single implementation returned the hardcoded constant `"IDEMIX"`. In a single-algorithm repository, algorithm dispatch via string identifiers is unnecessary overhead. The only two call sites were error messages in `impl.go`, which now use `reflect.TypeOf(opts)` for equivalent (and more informative) context.

### Changes

| File | Change |
|------|--------|
| `bccsp/types/crypto.go` | Remove `Algorithm() string` from `KeyGenOpts`, `KeyDerivOpts`, `KeyImportOpts` |
| `bccsp/types/idemixopts.go` | Remove `IDEMIX` constant + 11 `Algorithm()` method implementations |
| `bccsp/impl.go` | Replace `opts.Algorithm()` with `reflect.TypeOf(opts)` in 2 error messages |

### Interfaces after this change

```go
type KeyGenOpts interface {
    Ephemeral() bool
}
type KeyDerivOpts interface {
    Ephemeral() bool
}
type KeyImportOpts interface {
    Ephemeral() bool
}