### PR TITLE
Repository Modernization Plan - Phase 2D: Add missing IDEMIX_ARIES to mspTypeStrings map

### DIFF
--- a/msp/provider.go
+++ b/msp/provider.go
@@ -205,8 +205,9 @@ const (
 )
 
 var mspTypeStrings = map[ProviderType]string{
-	FABRIC: "bccsp",
-	IDEMIX: "idemix",
+	FABRIC:       "bccsp",
+	IDEMIX:       "idemix",
+	IDEMIX_ARIES: "idemix-aries",
 }
 
 // ProviderTypeToString returns a string that represents the ProviderType integer


### PR DESCRIPTION
## Add missing IDEMIX_ARIES to mspTypeStrings map

Fixes #63 

### What

Adds the `IDEMIX_ARIES` provider type to the `mspTypeStrings` lookup map in `msp/provider.go`.

### Why

The `IDEMIX_ARIES` constant was added to the `ProviderType` enum but the corresponding entry in `mspTypeStrings` was never added. The inline comment at the enum definition explicitly states: *"as new types are added to this set, the mspTypes map below must be extended"*.

This means `ProviderTypeToString(IDEMIX_ARIES)` was returning `""` instead of a meaningful identifier.

### Change

```go
// Before
var mspTypeStrings = map[ProviderType]string{
    FABRIC: "bccsp",
    IDEMIX: "idemix",
}

// After
var mspTypeStrings = map[ProviderType]string{
    FABRIC:       "bccsp",
    IDEMIX:       "idemix",
    IDEMIX_ARIES: "idemix-aries",
}