### PR TITLE
Repository Modernization Plan - Phase 3B: Refactor Aries scheme tests to table-driven subtests

### DIFF
--- a/bccsp/schemes/aries/credrequest_test.go
+++ b/bccsp/schemes/aries/credrequest_test.go
@@ -14,14 +14,17 @@ import (
 	"github.com/IBM/idemix/bccsp/types"
 	math "github.com/IBM/mathlib"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCredRequest(t *testing.T) {
+	curve := math.Curves[math.BLS12_381_BBS]
+
 	credProto := &aries.Cred{
-		BBS:   bbs.New(math.Curves[math.BLS12_381_BBS]),
-		Curve: math.Curves[math.BLS12_381_BBS],
+		BBS:   bbs.New(curve),
+		Curve: curve,
 	}
-	issuerProto := &aries.Issuer{math.Curves[math.BLS12_381_BBS]}
+	issuerProto := &aries.Issuer{Curve: curve}
 
 	attrs := []string{
 		"attr1",
@@ -31,144 +34,88 @@ func TestCredRequest(t *testing.T) {
 	}
 
 	isk, err := issuerProto.NewKey(attrs)
-	assert.NoError(t, err)
-	assert.NotNil(t, isk)
+	require.NoError(t, err)
 
 	ipk := isk.Public()
 
-	cr := &aries.CredRequest{
-		Curve: math.Curves[math.BLS12_381_BBS],
-	}
+	cr := &aries.CredRequest{Curve: curve}
 
-	rand, err := math.Curves[math.BLS12_381_BBS].Rand()
-	assert.NoError(t, err)
+	rand, err := curve.Rand()
+	require.NoError(t, err)
 
 	userProto := &aries.User{
-		Curve: math.Curves[math.BLS12_381_BBS],
+		Curve: curve,
 		Rng:   rand,
 	}
 
 	sk, err := userProto.NewKey()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	credReq, blinding, err := cr.Blind(sk, ipk, []byte("la la land"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = cr.BlindVerify(credReq, ipk, []byte("la la land"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	idemixAttrs := []types.IdemixAttribute{
-		{
-			Type:  types.IdemixBytesAttribute,
-			Value: []byte("msg1"),
-		},
-		{
-			Type:  types.IdemixIntAttribute,
-			Value: 3,
-		},
-		{
-			Type:  types.IdemixBytesAttribute,
-			Value: []byte("msg3"),
-		},
-		{
-			Type:  types.IdemixBytesAttribute,
-			Value: []byte("msg4"),
-		},
+	allAttrs := []types.IdemixAttribute{
+		{Type: types.IdemixBytesAttribute, Value: []byte("msg1")},
+		{Type: types.IdemixIntAttribute, Value: 3},
+		{Type: types.IdemixBytesAttribute, Value: []byte("msg3")},
+		{Type: types.IdemixBytesAttribute, Value: []byte("msg4")},
 	}
 
-	cred, err := credProto.Sign(isk, credReq, idemixAttrs)
-	assert.NoError(t, err)
+	cred, err := credProto.Sign(isk, credReq, allAttrs)
+	require.NoError(t, err)
 
 	cred, err = cr.Unblind(cred, blinding)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	err = credProto.Verify(sk, ipk, cred, idemixAttrs)
-	assert.NoError(t, err)
+	t.Run("full_lifecycle", func(t *testing.T) {
+		err := credProto.Verify(sk, ipk, cred, allAttrs)
+		assert.NoError(t, err)
+	})
 
-	idemixAttrs = []types.IdemixAttribute{
-		{
-			Type:  types.IdemixBytesAttribute,
-			Value: []byte("msg1"),
-		},
-		{
-			Type:  types.IdemixIntAttribute,
-			Value: 3,
-		},
-		{
-			Type:  types.IdemixBytesAttribute,
-			Value: []byte("msg3"),
-		},
-		{
-			Type: types.IdemixHiddenAttribute,
-		},
-	}
+	t.Run("verify_with_hidden_last_attr", func(t *testing.T) {
+		attrs := []types.IdemixAttribute{
+			{Type: types.IdemixBytesAttribute, Value: []byte("msg1")},
+			{Type: types.IdemixIntAttribute, Value: 3},
+			{Type: types.IdemixBytesAttribute, Value: []byte("msg3")},
+			{Type: types.IdemixHiddenAttribute},
+		}
+		err := credProto.Verify(sk, ipk, cred, attrs)
+		assert.NoError(t, err)
+	})
 
-	// verify succeeds when supplying hidden attrs
-	err = credProto.Verify(sk, ipk, cred, idemixAttrs)
-	assert.NoError(t, err)
+	t.Run("verify_with_hidden_first_and_last_attr", func(t *testing.T) {
+		attrs := []types.IdemixAttribute{
+			{Type: types.IdemixHiddenAttribute},
+			{Type: types.IdemixIntAttribute, Value: 3},
+			{Type: types.IdemixBytesAttribute, Value: []byte("msg3")},
+			{Type: types.IdemixHiddenAttribute},
+		}
+		err := credProto.Verify(sk, ipk, cred, attrs)
+		assert.NoError(t, err)
+	})
 
-	idemixAttrs = []types.IdemixAttribute{
-		{
-			Type: types.IdemixHiddenAttribute,
-		},
-		{
-			Type:  types.IdemixIntAttribute,
-			Value: 3,
-		},
-		{
-			Type:  types.IdemixBytesAttribute,
-			Value: []byte("msg3"),
-		},
-		{
-			Type: types.IdemixHiddenAttribute,
-		},
-	}
+	t.Run("wrong_attr_at_position_0", func(t *testing.T) {
+		attrs := []types.IdemixAttribute{
+			{Type: types.IdemixBytesAttribute, Value: []byte("msg2")},
+			{Type: types.IdemixIntAttribute, Value: 3},
+			{Type: types.IdemixBytesAttribute, Value: []byte("msg3")},
+			{Type: types.IdemixHiddenAttribute},
+		}
+		err := credProto.Verify(sk, ipk, cred, attrs)
+		assert.EqualError(t, err, "credential does not contain the correct attribute value at position [0]")
+	})
 
-	// verify succeeds when supplying hidden attrs and one of the hidden attrs is not the last
-	err = credProto.Verify(sk, ipk, cred, idemixAttrs)
-	assert.NoError(t, err)
-
-	idemixAttrs = []types.IdemixAttribute{
-		{
-			Type:  types.IdemixBytesAttribute,
-			Value: []byte("msg2"),
-		},
-		{
-			Type:  types.IdemixIntAttribute,
-			Value: 3,
-		},
-		{
-			Type:  types.IdemixBytesAttribute,
-			Value: []byte("msg3"),
-		},
-		{
-			Type: types.IdemixHiddenAttribute,
-		},
-	}
-
-	// verify fails when supplying wrong attrs
-	err = credProto.Verify(sk, ipk, cred, idemixAttrs)
-	assert.EqualError(t, err, "credential does not contain the correct attribute value at position [0]")
-
-	idemixAttrs = []types.IdemixAttribute{
-		{
-			Type:  types.IdemixBytesAttribute,
-			Value: []byte("msg1"),
-		},
-		{
-			Type:  types.IdemixIntAttribute,
-			Value: 2,
-		},
-		{
-			Type:  types.IdemixBytesAttribute,
-			Value: []byte("msg3"),
-		},
-		{
-			Type: types.IdemixHiddenAttribute,
-		},
-	}
-
-	// verify fails when supplying wrong attrs
-	err = credProto.Verify(sk, ipk, cred, idemixAttrs)
-	assert.EqualError(t, err, "credential does not contain the correct attribute value at position [1]")
+	t.Run("wrong_attr_at_position_1", func(t *testing.T) {
+		attrs := []types.IdemixAttribute{
+			{Type: types.IdemixBytesAttribute, Value: []byte("msg1")},
+			{Type: types.IdemixIntAttribute, Value: 2},
+			{Type: types.IdemixBytesAttribute, Value: []byte("msg3")},
+			{Type: types.IdemixHiddenAttribute},
+		}
+		err := credProto.Verify(sk, ipk, cred, attrs)
+		assert.EqualError(t, err, "credential does not contain the correct attribute value at position [1]")
+	})
 }

--- a/bccsp/schemes/aries/issuer_test.go
+++ b/bccsp/schemes/aries/issuer_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/IBM/idemix/bccsp/schemes/aries"
 	math "github.com/IBM/mathlib"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIssuer(t *testing.T) {
-	issuer := &aries.Issuer{math.Curves[math.BLS12_381_BBS]}
+	issuer := &aries.Issuer{Curve: math.Curves[math.BLS12_381_BBS]}
 
 	attrs := []string{
 		"attr1",
@@ -25,34 +26,42 @@ func TestIssuer(t *testing.T) {
 	}
 
 	isk, err := issuer.NewKey(attrs)
-	assert.NoError(t, err)
-	assert.NotNil(t, isk)
-
-	iskBytes, err := isk.Bytes()
-	assert.NoError(t, err)
-	assert.NotNil(t, iskBytes)
-
-	isk1, err := issuer.NewKeyFromBytes(iskBytes, attrs)
-	assert.NoError(t, err)
-	assert.NotNil(t, isk1)
-	assert.Equal(t, isk, isk1)
+	require.NoError(t, err)
+	require.NotNil(t, isk)
 
 	ipk := isk.Public()
-	assert.NotNil(t, ipk)
+	require.NotNil(t, ipk)
 
-	ipkBytes, err := ipk.Bytes()
-	assert.NoError(t, err)
-	assert.NotNil(t, ipkBytes)
+	t.Run("secret_key_roundtrip", func(t *testing.T) {
+		iskBytes, err := isk.Bytes()
+		require.NoError(t, err)
+		require.NotNil(t, iskBytes)
 
-	ipk1, err := issuer.NewPublicKeyFromBytes(ipkBytes, attrs)
-	assert.NoError(t, err)
-	assert.NotNil(t, ipk1)
-	assert.True(t, ipk.(*aries.IssuerPublicKey).PK.PointG2.Equals(ipk1.(*aries.IssuerPublicKey).PK.PointG2))
-	assert.Equal(t, ipk.(*aries.IssuerPublicKey).N, ipk1.(*aries.IssuerPublicKey).N)
+		isk1, err := issuer.NewKeyFromBytes(iskBytes, attrs)
+		assert.NoError(t, err)
+		assert.NotNil(t, isk1)
+		assert.Equal(t, isk, isk1)
+	})
 
-	_, err = issuer.NewKeyFromBytes([]byte("resistance is futile"), attrs)
-	assert.EqualError(t, err, "UnmarshalPrivateKey failed [invalid size of private key]")
+	t.Run("public_key_roundtrip", func(t *testing.T) {
+		ipkBytes, err := ipk.Bytes()
+		require.NoError(t, err)
+		require.NotNil(t, ipkBytes)
 
-	_, err = issuer.NewPublicKeyFromBytes([]byte("resresistance is futile"), attrs)
-	assert.EqualError(t, err, "UnmarshalPublicKey failed [invalid size of public key]")
+		ipk1, err := issuer.NewPublicKeyFromBytes(ipkBytes, attrs)
+		assert.NoError(t, err)
+		assert.NotNil(t, ipk1)
+		assert.True(t, ipk.(*aries.IssuerPublicKey).PK.PointG2.Equals(ipk1.(*aries.IssuerPublicKey).PK.PointG2))
+		assert.Equal(t, ipk.(*aries.IssuerPublicKey).N, ipk1.(*aries.IssuerPublicKey).N)
+	})
+
+	t.Run("invalid_secret_key_bytes", func(t *testing.T) {
+		_, err := issuer.NewKeyFromBytes([]byte("resistance is futile"), attrs)
+		assert.EqualError(t, err, "UnmarshalPrivateKey failed [invalid size of private key]")
+	})
+
+	t.Run("invalid_public_key_bytes", func(t *testing.T) {
+		_, err := issuer.NewPublicKeyFromBytes([]byte("resresistance is futile"), attrs)
+		assert.EqualError(t, err, "UnmarshalPublicKey failed [invalid size of public key]")
+	})
 }

--- a/bccsp/schemes/aries/nymsigner_test.go
+++ b/bccsp/schemes/aries/nymsigner_test.go
@@ -6,20 +6,22 @@ SPDX-License-Identifier: Apache-2.0
 package aries_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/IBM/idemix/bbs"
 	"github.com/IBM/idemix/bccsp/schemes/aries"
 	math "github.com/IBM/mathlib"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNymSigner(t *testing.T) {
 	curve := math.Curves[math.BLS12_381_BBS]
 	rand, err := curve.Rand()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	issuerProto := &aries.Issuer{curve}
+	issuerProto := &aries.Issuer{Curve: curve}
 
 	attrs := []string{
 		"attr1",
@@ -29,8 +31,7 @@ func TestNymSigner(t *testing.T) {
 	}
 
 	isk, err := issuerProto.NewKey(attrs)
-	assert.NoError(t, err)
-	assert.NotNil(t, isk)
+	require.NoError(t, err)
 
 	_ipk := isk.Public()
 	ipk := _ipk.(*aries.IssuerPublicKey)
@@ -44,41 +45,53 @@ func TestNymSigner(t *testing.T) {
 	rNym := curve.NewRandomZr(rand)
 
 	for skPos := range attrs {
-		signer.UserSecretKeyIndex = skPos
+		t.Run(fmt.Sprintf("skPos=%d", skPos), func(t *testing.T) {
+			signer.UserSecretKeyIndex = skPos
 
-		cb := bbs.NewCommitmentBuilder(2)
-		cb.Add(ipk.PKwG.H0, rNym)
-		cb.Add(ipk.PKwG.H[skPos], sk)
-		nym := cb.Build()
+			cb := bbs.NewCommitmentBuilder(2)
+			cb.Add(ipk.PKwG.H0, rNym)
+			cb.Add(ipk.PKwG.H[skPos], sk)
+			nym := cb.Build()
 
-		sig, err := signer.Sign(sk, nym, rNym, _ipk, []byte("ciao"))
-		assert.NoError(t, err)
+			t.Run("happy_path", func(t *testing.T) {
+				sig, err := signer.Sign(sk, nym, rNym, _ipk, []byte("ciao"))
+				assert.NoError(t, err)
 
-		err = signer.Verify(_ipk, nym, sig, []byte("ciao"), skPos)
-		assert.NoError(t, err)
+				err = signer.Verify(_ipk, nym, sig, []byte("ciao"), skPos)
+				assert.NoError(t, err)
+			})
 
-		sig, err = signer.Sign(sk, nym, curve.NewRandomZr(rand), _ipk, []byte("ciao"))
-		assert.NoError(t, err)
+			t.Run("wrong_randomness", func(t *testing.T) {
+				sig, err := signer.Sign(sk, nym, curve.NewRandomZr(rand), _ipk, []byte("ciao"))
+				assert.NoError(t, err)
 
-		err = signer.Verify(_ipk, nym, sig, []byte("ciao"), skPos)
-		assert.EqualError(t, err, "contribution is not zero")
+				err = signer.Verify(_ipk, nym, sig, []byte("ciao"), skPos)
+				assert.EqualError(t, err, "contribution is not zero")
+			})
 
-		sig, err = signer.Sign(curve.NewRandomZr(rand), nym, rNym, _ipk, []byte("ciao"))
-		assert.NoError(t, err)
+			t.Run("wrong_secret_key", func(t *testing.T) {
+				sig, err := signer.Sign(curve.NewRandomZr(rand), nym, rNym, _ipk, []byte("ciao"))
+				assert.NoError(t, err)
 
-		err = signer.Verify(_ipk, nym, sig, []byte("ciao"), skPos)
-		assert.EqualError(t, err, "contribution is not zero")
+				err = signer.Verify(_ipk, nym, sig, []byte("ciao"), skPos)
+				assert.EqualError(t, err, "contribution is not zero")
+			})
 
-		sig, err = signer.Sign(sk, curve.GenG1.Mul(curve.NewRandomZr(rand)), rNym, _ipk, []byte("ciao"))
-		assert.NoError(t, err)
+			t.Run("wrong_nym_at_sign", func(t *testing.T) {
+				sig, err := signer.Sign(sk, curve.GenG1.Mul(curve.NewRandomZr(rand)), rNym, _ipk, []byte("ciao"))
+				assert.NoError(t, err)
 
-		err = signer.Verify(_ipk, nym, sig, []byte("ciao"), skPos)
-		assert.EqualError(t, err, "contribution is not zero")
+				err = signer.Verify(_ipk, nym, sig, []byte("ciao"), skPos)
+				assert.EqualError(t, err, "contribution is not zero")
+			})
 
-		sig, err = signer.Sign(sk, nym, rNym, _ipk, []byte("ciao"))
-		assert.NoError(t, err)
+			t.Run("wrong_nym_at_verify", func(t *testing.T) {
+				sig, err := signer.Sign(sk, nym, rNym, _ipk, []byte("ciao"))
+				assert.NoError(t, err)
 
-		err = signer.Verify(_ipk, curve.GenG1.Mul(curve.NewRandomZr(rand)), sig, []byte("ciao"), skPos)
-		assert.EqualError(t, err, "contribution is not zero")
+				err = signer.Verify(_ipk, curve.GenG1.Mul(curve.NewRandomZr(rand)), sig, []byte("ciao"), skPos)
+				assert.EqualError(t, err, "contribution is not zero")
+			})
+		})
 	}
 }

--- a/bccsp/schemes/aries/revocation_test.go
+++ b/bccsp/schemes/aries/revocation_test.go
@@ -18,33 +18,36 @@ import (
 func TestRevocation(t *testing.T) {
 	curve := math.Curves[math.BLS12_381_BBS]
 	rand, err := curve.Rand()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rev := &aries.RevocationAuthority{
 		Rng:   rand,
 		Curve: curve,
 	}
 
-	// Generate a revocation key pair
 	revocationKey, err := rev.NewKey()
 	require.NoError(t, err)
 
-	// Create CRI that contains no revocation mechanism
 	epoch := 0
 	cri, err := rev.Sign(revocationKey, [][]byte{}, epoch, idemix.AlgNoRevocation)
 	require.NoError(t, err)
-	err = rev.Verify(&revocationKey.PublicKey, cri, epoch, idemix.AlgNoRevocation)
-	require.NoError(t, err)
 
-	// make sure that epoch pk is not valid in future epoch
-	err = rev.Verify(&revocationKey.PublicKey, cri, epoch+1, idemix.AlgNoRevocation)
-	require.Error(t, err)
+	t.Run("sign_and_verify_happy_path", func(t *testing.T) {
+		err := rev.Verify(&revocationKey.PublicKey, cri, epoch, idemix.AlgNoRevocation)
+		assert.NoError(t, err)
+	})
 
-	bytes := revocationKey.D.Bytes()
-	revocationKey, err = rev.NewKeyFromBytes(bytes)
-	require.NoError(t, err)
+	t.Run("wrong_epoch_fails", func(t *testing.T) {
+		err := rev.Verify(&revocationKey.PublicKey, cri, epoch+1, idemix.AlgNoRevocation)
+		assert.Error(t, err)
+	})
 
-	err = rev.Verify(&revocationKey.PublicKey, cri, epoch, idemix.AlgNoRevocation)
-	require.NoError(t, err)
+	t.Run("key_roundtrip", func(t *testing.T) {
+		bytes := revocationKey.D.Bytes()
+		restoredKey, err := rev.NewKeyFromBytes(bytes)
+		require.NoError(t, err)
 
+		err = rev.Verify(&restoredKey.PublicKey, cri, epoch, idemix.AlgNoRevocation)
+		assert.NoError(t, err)
+	})
 }

--- a/bccsp/schemes/aries/user_test.go
+++ b/bccsp/schemes/aries/user_test.go
@@ -12,10 +12,11 @@ import (
 	"github.com/IBM/idemix/bccsp/schemes/aries"
 	math "github.com/IBM/mathlib"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUser(t *testing.T) {
-	issuer := &aries.Issuer{math.Curves[math.BLS12_381_BBS]}
+	issuer := &aries.Issuer{Curve: math.Curves[math.BLS12_381_BBS]}
 
 	attrs := []string{
 		"attr1",
@@ -25,13 +26,12 @@ func TestUser(t *testing.T) {
 	}
 
 	isk, err := issuer.NewKey(attrs)
-	assert.NoError(t, err)
-	assert.NotNil(t, isk)
+	require.NoError(t, err)
 
 	ipk := isk.Public()
 
 	rand, err := math.Curves[math.BLS12_381_BBS].Rand()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	user := &aries.User{
 		Curve: math.Curves[math.BLS12_381_BBS],
@@ -39,16 +39,17 @@ func TestUser(t *testing.T) {
 	}
 
 	sk, err := user.NewKey()
-	assert.NoError(t, err)
-	assert.NotNil(t, sk)
+	require.NoError(t, err)
 
-	sk1, err := user.NewKeyFromBytes(sk.Bytes())
-	assert.NoError(t, err)
-	assert.NotNil(t, sk1)
-	assert.Equal(t, sk, sk1)
+	t.Run("key_roundtrip", func(t *testing.T) {
+		sk1, err := user.NewKeyFromBytes(sk.Bytes())
+		assert.NoError(t, err)
+		assert.NotNil(t, sk1)
+		assert.Equal(t, sk, sk1)
+	})
 
 	nym, r, err := user.MakeNym(sk, ipk)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	nymBytes := nym.Bytes()
 	rBytes := r.Bytes()
@@ -56,32 +57,50 @@ func TestUser(t *testing.T) {
 	bothBytes = append(bothBytes, rBytes...)
 	bothBytes = append(bothBytes, nymBytes...)
 
-	nym1, err := user.NewPublicNymFromBytes(nymBytes)
-	assert.NoError(t, err)
-	assert.NotNil(t, nym)
-	assert.True(t, nym.Equals(nym1))
+	t.Run("public_nym_roundtrip", func(t *testing.T) {
+		nym1, err := user.NewPublicNymFromBytes(nymBytes)
+		assert.NoError(t, err)
+		assert.NotNil(t, nym1)
+		assert.True(t, nym.Equals(nym1))
+	})
 
-	nym1, r1, err := user.NewNymFromBytes(bothBytes)
-	assert.NoError(t, err)
-	assert.NotNil(t, nym)
-	assert.True(t, nym.Equals(nym1))
-	assert.NotNil(t, r1)
-	assert.Equal(t, r, r1)
+	t.Run("nym_roundtrip", func(t *testing.T) {
+		nym1, r1, err := user.NewNymFromBytes(bothBytes)
+		assert.NoError(t, err)
+		assert.NotNil(t, nym1)
+		assert.True(t, nym.Equals(nym1))
+		assert.NotNil(t, r1)
+		assert.Equal(t, r, r1)
+	})
 
-	nymBytes[len(nymBytes)-1] = 0
-	_, err = user.NewPublicNymFromBytes(nymBytes)
-	assert.EqualError(t, err, "failure [set bytes failed [point is not on curve]]")
+	t.Run("corrupted_public_nym_bytes", func(t *testing.T) {
+		corrupted := make([]byte, len(nymBytes))
+		copy(corrupted, nymBytes)
+		corrupted[len(corrupted)-1] = 0
+		_, err := user.NewPublicNymFromBytes(corrupted)
+		assert.EqualError(t, err, "failure [set bytes failed [point is not on curve]]")
+	})
 
-	bothBytes[len(bothBytes)-1] = 0
-	_, _, err = user.NewNymFromBytes(bothBytes)
-	assert.EqualError(t, err, "failure [set bytes failed [point is not on curve]]")
+	t.Run("corrupted_nym_bytes", func(t *testing.T) {
+		corrupted := make([]byte, len(bothBytes))
+		copy(corrupted, bothBytes)
+		corrupted[len(corrupted)-1] = 0
+		_, _, err := user.NewNymFromBytes(corrupted)
+		assert.EqualError(t, err, "failure [set bytes failed [point is not on curve]]")
+	})
 
-	_, err = user.NewKeyFromBytes([]byte("yän-dər"))
-	assert.EqualError(t, err, "invalid length, expected [32], got [9]")
+	t.Run("invalid_key_bytes", func(t *testing.T) {
+		_, err := user.NewKeyFromBytes([]byte("yän-dər"))
+		assert.EqualError(t, err, "invalid length, expected [32], got [9]")
+	})
 
-	_, err = user.NewPublicNymFromBytes([]byte("yän-dər"))
-	assert.EqualError(t, err, "invalid length, expected [96], got [9]")
+	t.Run("invalid_public_nym_length", func(t *testing.T) {
+		_, err := user.NewPublicNymFromBytes([]byte("yän-dər"))
+		assert.EqualError(t, err, "invalid length, expected [96], got [9]")
+	})
 
-	_, _, err = user.NewNymFromBytes([]byte("yän-dər"))
-	assert.EqualError(t, err, "invalid length, expected [128], got [9]")
+	t.Run("invalid_nym_length", func(t *testing.T) {
+		_, _, err := user.NewNymFromBytes([]byte("yän-dər"))
+		assert.EqualError(t, err, "invalid length, expected [128], got [9]")
+	})
 }


### PR DESCRIPTION
## test: refactor Aries scheme tests to table-driven subtests

fixes #63 

Wrap test logic in t.Run with descriptive subtest names across 5 Aries test files: nymsigner, revocation, issuer, user, and credrequest.

Changes:
- nymsigner_test.go: wrap loop body in t.Run(skPos=N/...) with 5 named subtests per position (happy_path, wrong_randomness, wrong_secret_key, wrong_nym_at_sign, wrong_nym_at_verify)
- revocation_test.go: split into 3 subtests (sign_and_verify_happy_path, wrong_epoch_fails, key_roundtrip)
- issuer_test.go: split into 4 subtests (secret_key_roundtrip, public_key_roundtrip, invalid_secret_key_bytes, invalid_public_key_bytes)
- user_test.go: split into 8 subtests (key_roundtrip, public_nym_roundtrip, nym_roundtrip, corrupted_public_nym_bytes, corrupted_nym_bytes, invalid_key_bytes, invalid_public_nym_length, invalid_nym_length)
- credrequest_test.go: split into 5 subtests (full_lifecycle, verify_with_hidden_last_attr, verify_with_hidden_first_and_last_attr, wrong_attr_at_position_0, wrong_attr_at_position_1)

Also switched setup assertions from assert to require so tests fail fast on shared-setup errors, used named struct fields, and deduplicated curve references into local variables.