### PR TITLE
dlog remove deprecation

### DIFF
--- a/bccsp/schemes/dlog/crypto/idemix.go
+++ b/bccsp/schemes/dlog/crypto/idemix.go
@@ -4,9 +4,6 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Deprecated: Package idemix implements the legacy CL-signature based scheme.
-// It will be removed in Phase 6 of the modernization plan. Use
-// bccsp/schemes/aries (BBS+) instead.
 package idemix
 
 import (


### PR DESCRIPTION
This PR removes the comment that deprecates the dlog implementation. It is still needed by Fabric and the fabric smart client.