### PR TITLE
fix(bbs): eliminate data race in f2192 curve cache

### DIFF
--- a/bbs/fr.go
+++ b/bbs/fr.go
@@ -25,17 +25,23 @@ var (
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
 		0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
 	}
-	f2192Cache = make(map[*ml.Curve]*ml.Zr)
+	//nolint:gochecknoglobals
+	f2192Cache = func() map[*ml.Curve]*ml.Zr {
+		m := make(map[*ml.Curve]*ml.Zr, len(ml.Curves))
+		for _, c := range ml.Curves {
+			m[c] = c.NewZrFromBytes(f2192Bytes)
+		}
+
+		return m
+	}()
 )
 
 func f2192(curve *ml.Curve) *ml.Zr {
 	if cached, ok := f2192Cache[curve]; ok {
 		return cached
 	}
-	val := curve.NewZrFromBytes(f2192Bytes)
-	f2192Cache[curve] = val
 
-	return val
+	return curve.NewZrFromBytes(f2192Bytes)
 }
 
 func FrFromOKM(message []byte, curve *ml.Curve) *ml.Zr {

--- a/bbs/fr_test.go
+++ b/bbs/fr_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package bbs
+
+import (
+	"sync"
+	"testing"
+
+	ml "github.com/IBM/mathlib"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrFromOKMConcurrent(t *testing.T) {
+	message := []byte("test message")
+
+	for i, curve := range ml.Curves {
+		const workers = 16
+		results := make([]*ml.Zr, workers)
+
+		var wg sync.WaitGroup
+		wg.Add(workers)
+		for w := range workers {
+			go func(w int) {
+				defer wg.Done()
+				results[w] = FrFromOKM(message, curve)
+			}(w)
+		}
+		wg.Wait()
+
+		expected := FrFromOKM(message, curve)
+		for w, r := range results {
+			require.True(t, expected.Equals(r), "curve %d, worker %d", i, w)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #83

`f2192()` cached the constant 2^192 per curve in a package-level map that was lazily populated with no synchronization; concurrent first-use calls raced on it (race report in #83).

This precomputes the entry for every curve in `ml.Curves` at package init and treats the map as read-only afterwards, so lookups stay lock-free. A curve outside the registry falls back to computing the value without caching, which keeps the map read-only.

The new `TestFrFromOKMConcurrent` exercises concurrent first-use lookups for every curve: it reliably reports the race under `-race` on the previous implementation and passes with this change. `go build ./...` and `go test -race ./bbs/...` pass locally.